### PR TITLE
BF: setup.py: Install data files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -155,6 +155,12 @@ setup(
     },
     cmdclass=cmdclass,
     package_data={
-        'reproman': []
+        'reproman':
+            findsome(opj("distributions", "tests", "files"), {"yml", "yaml"}) +
+            findsome("examples", {"trig", "yml", "yaml"}) +
+            findsome(opj("formats", "tests", "files"), {"yml", "yaml"}) +
+            findsome(opj("interface", "tests"), {"yml", "yaml"}) +
+            findsome(opj("interface", "tests", "files"), {"yml", "yaml"}) +
+            findsome(opj("tests", "files"), {"cfg"})
     }
 )


### PR DESCRIPTION
Fixes #365.

---

The last commit temporarily adjusts Travis to run `reproman test`.  I want to see if it passes but plan to drop it afterward.

Check I ran to see if the data files got installed as expected:

```
(codebase)% git ls-files reproman | grep -v \.py$ | sort >/tmp/from-repo
(site-packages of virtualenv)% find reproman -type f | grep -v '\.pyc\?$' | sort >/tmp/from-site-packages
% diff /tmp/from-repo /tmp/from-site-packages && echo same
same
```

