### PR TITLE
BF: virtualenv: Don't return internal symlinks as unknown paths

### DIFF
--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -17,6 +17,7 @@ import logging
 
 from reproman.cmd import Runner
 from reproman.utils import chpwd
+from reproman.utils import on_linux
 from reproman.tests.utils import create_pymodule
 from reproman.tests.utils import skip_if_no_network, assert_is_subset_recur
 from reproman.tests.utils import swallow_logs
@@ -53,6 +54,7 @@ def venv_test_dir():
     return test_dir
 
 
+@pytest.mark.skipif(not on_linux, reason="Test assumes GNU/Linux system")
 @pytest.mark.integration
 def test_venv_identify_distributions(venv_test_dir):
     paths = [

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -57,17 +57,16 @@ def venv_test_dir():
 @pytest.mark.skipif(not on_linux, reason="Test assumes GNU/Linux system")
 @pytest.mark.integration
 def test_venv_identify_distributions(venv_test_dir):
-    libpaths = [
-        os.path.join("lib", PY_VERSION, "site-packages", "yaml", "parser.py"),
-        os.path.join("lib", PY_VERSION, "site-packages", "attr", "filters.py"),
-    ]
+    libpaths = {p[-1]: os.path.join("lib", PY_VERSION, *p)
+                for p in [("site-packages", "yaml", "parser.py"),
+                          ("site-packages", "attr", "filters.py")]}
 
     with chpwd(venv_test_dir):
         path_args = [
             # Both full ...
-            os.path.join(venv_test_dir, "venv0", libpaths[0]),
+            os.path.join(venv_test_dir, "venv0", libpaths["parser.py"]),
             # ... and relative paths work.
-            os.path.join("venv1", libpaths[1]),
+            os.path.join("venv1", libpaths["filters.py"]),
             # A virtualenv file that isn't part of any particular package.
             os.path.join("venv1", "bin", "python"),
         ]
@@ -89,11 +88,13 @@ def test_venv_identify_distributions(venv_test_dir):
         assert len(distributions.environments) == 2
 
         expect = {"environments":
-                  [{"packages": [{"files": [libpaths[0]], "name": "PyYAML",
+                  [{"packages": [{"files": [libpaths["parser.py"]],
+                                  "name": "PyYAML",
                                   "editable": False},
                                  {"files": [], "name": "nmtest",
                                   "editable": True}]},
-                   {"packages": [{"files": [libpaths[1]], "name": "attrs",
+                   {"packages": [{"files": [libpaths["filters.py"]],
+                                  "name": "attrs",
                                   "editable": False}]}]}
         assert_is_subset_recur(expect, attr.asdict(distributions), [dict, list])
 

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -57,7 +57,7 @@ def venv_test_dir():
 @pytest.mark.skipif(not on_linux, reason="Test assumes GNU/Linux system")
 @pytest.mark.integration
 def test_venv_identify_distributions(venv_test_dir):
-    paths = [
+    libpaths = [
         os.path.join("lib", PY_VERSION, "site-packages", "yaml", "parser.py"),
         os.path.join("lib", PY_VERSION, "site-packages", "attr", "filters.py"),
     ]
@@ -65,9 +65,9 @@ def test_venv_identify_distributions(venv_test_dir):
     with chpwd(venv_test_dir):
         path_args = [
             # Both full ...
-            os.path.join(venv_test_dir, "venv0", paths[0]),
+            os.path.join(venv_test_dir, "venv0", libpaths[0]),
             # ... and relative paths work.
-            os.path.join("venv1", paths[1]),
+            os.path.join("venv1", libpaths[1]),
             # A virtualenv file that isn't part of any particular package.
             os.path.join("venv1", "bin", "python"),
         ]
@@ -89,11 +89,11 @@ def test_venv_identify_distributions(venv_test_dir):
         assert len(distributions.environments) == 2
 
         expect = {"environments":
-                  [{"packages": [{"files": [paths[0]], "name": "PyYAML",
+                  [{"packages": [{"files": [libpaths[0]], "name": "PyYAML",
                                   "editable": False},
                                  {"files": [], "name": "nmtest",
                                   "editable": True}]},
-                   {"packages": [{"files": [paths[1]], "name": "attrs",
+                   {"packages": [{"files": [libpaths[1]], "name": "attrs",
                                   "editable": False}]}]}
         assert_is_subset_recur(expect, attr.asdict(distributions), [dict, list])
 

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -64,6 +64,8 @@ def test_venv_identify_distributions(venv_test_dir):
             os.path.join(venv_test_dir, "venv0", paths[0]),
             # ... and relative paths work.
             os.path.join("venv1", paths[1]),
+            # A virtualenv file that isn't part of any particular package.
+            os.path.join("venv1", "bin", "python"),
         ]
         path_args.append("/sbin/iptables")
 
@@ -73,6 +75,8 @@ def test_venv_identify_distributions(venv_test_dir):
         assert len(dists) == 1
 
         distributions, unknown_files = dists[0]
+        # Unknown files do not include "venv0/bin/python", which is a link
+        # another path within venv0.
         assert unknown_files == {
             "/sbin/iptables",
             # The editable package was added by VenvTracer as an unknown file.

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -58,7 +58,8 @@ def venv_test_dir():
 @pytest.mark.integration
 def test_venv_identify_distributions(venv_test_dir):
     libpaths = {p[-1]: os.path.join("lib", PY_VERSION, *p)
-                for p in [("site-packages", "yaml", "parser.py"),
+                for p in [("abc.py",),
+                          ("site-packages", "yaml", "parser.py"),
                           ("site-packages", "attr", "filters.py")]}
 
     with chpwd(venv_test_dir):
@@ -69,6 +70,8 @@ def test_venv_identify_distributions(venv_test_dir):
             os.path.join("venv1", libpaths["filters.py"]),
             # A virtualenv file that isn't part of any particular package.
             os.path.join("venv1", "bin", "python"),
+            # A link to the outside world.
+            os.path.join("venv1", libpaths["abc.py"])
         ]
         path_args.append("/sbin/iptables")
 
@@ -79,9 +82,11 @@ def test_venv_identify_distributions(venv_test_dir):
 
         distributions, unknown_files = dists[0]
         # Unknown files do not include "venv0/bin/python", which is a link
-        # another path within venv0.
+        # another path within venv0, but they do include the link to the system
+        # abc.py.
         assert unknown_files == {
             "/sbin/iptables",
+            op.realpath(os.path.join("venv1", libpaths["abc.py"])),
             # The editable package was added by VenvTracer as an unknown file.
             os.path.join(venv_test_dir, "minimal_pymodule")}
 

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -36,22 +36,20 @@ def venv_test_dir():
     if os.path.exists(test_dir):
         return test_dir
 
-    runner = Runner()
-
     os.makedirs(test_dir)
     pymod_dir = os.path.join(test_dir, "minimal_pymodule")
     create_pymodule(pymod_dir)
 
-    with chpwd(test_dir):
-        pip0 = op.join("venv0", "bin", "pip")
-        pip1 = op.join("venv1", "bin", "pip")
-        runner.run(["virtualenv", "--python", PY_VERSION, "venv0"])
-        runner.run(["virtualenv", "--python", PY_VERSION, "venv1"])
-        runner.run([pip0, "install", "pyyaml"])
-        runner.run([pip0, "install", "-e", pymod_dir])
-        runner.run([pip1, "install", "attrs"])
-        # Make sure we're compatible with older pips.
-        runner.run([pip1, "install", "pip==9.0.3"])
+    runner = Runner(cwd=test_dir)
+    pip0 = op.join("venv0", "bin", "pip")
+    pip1 = op.join("venv1", "bin", "pip")
+    runner.run(["virtualenv", "--python", PY_VERSION, "venv0"])
+    runner.run(["virtualenv", "--python", PY_VERSION, "venv1"])
+    runner.run([pip0, "install", "pyyaml"])
+    runner.run([pip0, "install", "-e", pymod_dir])
+    runner.run([pip1, "install", "attrs"])
+    # Make sure we're compatible with older pips.
+    runner.run([pip1, "install", "pip==9.0.3"])
     return test_dir
 
 

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -37,26 +37,30 @@ def venv_test_dir():
         return test_dir
 
     runner = Runner()
-    runner.run(["mkdir", "-p", test_dir])
 
+    os.makedirs(test_dir)
     pymod_dir = os.path.join(test_dir, "minimal_pymodule")
     create_pymodule(pymod_dir)
 
     with chpwd(test_dir):
+        pip0 = op.join("venv0", "bin", "pip")
+        pip1 = op.join("venv1", "bin", "pip")
         runner.run(["virtualenv", "--python", PY_VERSION, "venv0"])
         runner.run(["virtualenv", "--python", PY_VERSION, "venv1"])
-        runner.run(["./venv0/bin/pip", "install", "pyyaml"])
-        runner.run(["./venv0/bin/pip", "install", "-e", pymod_dir])
-        runner.run(["./venv1/bin/pip", "install", "attrs"])
+        runner.run([pip0, "install", "pyyaml"])
+        runner.run([pip0, "install", "-e", pymod_dir])
+        runner.run([pip1, "install", "attrs"])
         # Make sure we're compatible with older pips.
-        runner.run(["./venv1/bin/pip", "install", "pip==9.0.3"])
+        runner.run([pip1, "install", "pip==9.0.3"])
     return test_dir
 
 
 @pytest.mark.integration
 def test_venv_identify_distributions(venv_test_dir):
-    paths = ["lib/" + PY_VERSION + "/site-packages/yaml/parser.py",
-             "lib/" + PY_VERSION + "/site-packages/attr/filters.py"]
+    paths = [
+        os.path.join("lib", PY_VERSION, "site-packages", "yaml", "parser.py"),
+        os.path.join("lib", PY_VERSION, "site-packages", "attr", "filters.py"),
+    ]
 
     with chpwd(venv_test_dir):
         path_args = [
@@ -97,8 +101,10 @@ def test_venv_identify_distributions(venv_test_dir):
 @pytest.mark.integration
 def test_venv_install(venv_test_dir, tmpdir):
     tmpdir = str(tmpdir)
-    paths = ["lib/" + PY_VERSION + "/site-packages/yaml/parser.py",
-             "lib/" + PY_VERSION + "/site-packages/attr/filters.py"]
+    paths = [
+        op.join("lib", PY_VERSION, "site-packages", "yaml", "parser.py"),
+        op.join("lib", PY_VERSION, "site-packages", "attr", "filters.py"),
+    ]
 
     tracer = VenvTracer()
     dists = list(

--- a/reproman/distributions/venv.py
+++ b/reproman/distributions/venv.py
@@ -160,7 +160,12 @@ class VenvTracer(DistributionTracer):
             # system wide installation of python
             for path in unknown_files.copy():
                 if is_subpath(path, venv_path) and op.islink(path):
-                    unknown_files.add(op.realpath(path))
+                    rpath = op.realpath(path)
+                    # ... but the resolved link may point to another path under
+                    # the environment (e.g., bin/python -> bin/python3), and we
+                    # don't want to pass that back out as unknown.
+                    if not is_subpath(rpath, venv_path):
+                        unknown_files.add(rpath)
                     unknown_files.remove(path)
 
             packages = []


### PR DESCRIPTION
We resolve virtualenv symlinks and report them as unknown files
because links in the virtual environment may point to system
packages ($ENV/lib/python3.5/types.py -> /usr/lib/python3.5/types.py),
and we want to detect those resolved paths with another
tracer (usually DebTracer) on the next `retrace` iteration.

However, a symlink may point to another file under the same virtual
environment, as is the case with "$ENV/bin/python -> $ENV/bin/pythonX"
links.  Returning the resolved path of an internal link as an unknown
file to `retrace` will result in a duplicate [*] virtualenv
distribution because the path will reach the virtualenv tracer on the
next iteration.  (This can in turn lead to duplicate Git distributions
if any of the virtualenv packages are editable.)

Re: #367

[*]: Or at least near-duplicate: the second distribution will lack any
     files that were assigned to virtualenv packages during the first
     pass.