### PR TITLE
Add new module for defining test skip conditions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ script:
   - python setup.py build
   - if [ ! -z "$REPROMAN_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # - $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package reproman --logging-level=INFO
-  - coverage run `which py.test` -s --integration reproman
+  - coverage run `which py.test` -s -rs --integration reproman
   - if [ ! -z "$REPROMAN_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD make -C docs html doctest

--- a/reproman/distributions/tests/test_conda.py
+++ b/reproman/distributions/tests/test_conda.py
@@ -18,7 +18,8 @@ import attr
 
 from reproman.formats.reproman import RepromanProvenance
 from reproman.tests.utils import create_pymodule
-from reproman.tests.utils import skip_if_no_network, assert_is_subset_recur
+from reproman.tests.utils import assert_is_subset_recur
+from reproman.tests.skip import mark
 
 from reproman.distributions.conda import CondaTracer, CondaDistribution, \
     CondaEnvironment, CondaPackage, CondaChannel, \
@@ -98,7 +99,7 @@ def test_create_conda_export():
 
 
 @pytest.mark.integration
-@skip_if_no_network
+@mark.skipif_no_network
 def test_conda_init_install_and_detect():
     test_dir = "/tmp/reproman_conda/miniconda"
 

--- a/reproman/distributions/tests/test_debian.py
+++ b/reproman/distributions/tests/test_debian.py
@@ -24,10 +24,10 @@ import pytest
 import mock
 
 from reproman.utils import swallow_logs
-from reproman.tests.utils import skip_if_no_apt_cache
+from reproman.tests.skip import mark
 
 
-@skip_if_no_apt_cache
+@mark.skipif_no_apt_cache
 def test_dpkg_manager_identify_packages():
     files = ["/sbin/iptables"]
     tracer = DebTracer()
@@ -59,7 +59,7 @@ def test_dpkg_manager_identify_packages():
 
 
 @pytest.mark.integration
-@skip_if_no_apt_cache
+@mark.skipif_no_apt_cache
 def test_check_bin_packages():
     # Gather files in /usr/bin and /usr/lib
     files = list_all_files("/usr/bin") + list_all_files("/usr/lib")

--- a/reproman/distributions/tests/test_docker.py
+++ b/reproman/distributions/tests/test_docker.py
@@ -15,11 +15,11 @@ from ...distributions.docker import DockerImage
 from ...distributions.docker import DockerTracer
 from ...resource.session import get_local_session
 from ...support.exceptions import CommandError
-from ...tests.utils import skip_if_no_docker_engine, skip_if_no_network
+from ...tests.skip import mark
 
 
-@skip_if_no_network
-@skip_if_no_docker_engine
+@mark.skipif_no_network
+@mark.skipif_no_docker_engine
 def test_docker_trace_tag():
     client = docker.Client()
     client.pull('alpine:3.6')
@@ -36,8 +36,8 @@ def test_docker_trace_tag():
     assert 'non-existent-image' in remaining_files
 
 
-@skip_if_no_network
-@skip_if_no_docker_engine
+@mark.skipif_no_network
+@mark.skipif_no_docker_engine
 def test_docker_trace_id():
     client = docker.Client()
     repo_id = 'sha256:f625bd3ff910ad2c68a405ccc5e294d2714fc8cfe7b5d80a8331c72ad5cc7630'
@@ -58,8 +58,8 @@ def test_docker_trace_id():
     assert dist.images[0].created == '2018-01-09T21:10:38.538173323Z'
 
 
-@skip_if_no_network
-@skip_if_no_docker_engine
+@mark.skipif_no_network
+@mark.skipif_no_docker_engine
 def test_docker_trace_local_image():
     client = docker.Client()
     client.pull('alpine:3.6')
@@ -80,8 +80,8 @@ def test_docker_trace_local_image():
     client.remove_image(new_image['Id'])
 
 
-@skip_if_no_network
-@skip_if_no_docker_engine
+@mark.skipif_no_network
+@mark.skipif_no_docker_engine
 def test_docker_distribution():
 
     client = docker.Client()

--- a/reproman/distributions/tests/test_redhat.py
+++ b/reproman/distributions/tests/test_redhat.py
@@ -17,14 +17,14 @@ from ...distributions.redhat import RPMPackage
 from ...distributions.redhat import RedhatDistribution
 from ...formats import Provenance
 from ...resource.docker_container import DockerContainer
-from ...tests.utils import skip_if_no_network, skip_if_no_docker_engine
+from ...tests.skip import skipif
 from ...utils import swallow_logs
 
 
-@skip_if_no_docker_engine
 @pytest.fixture(scope='function')
 def docker_container():
-    skip_if_no_network()
+    skipif.no_network()
+    skipif.no_docker_engine()
     name = str(uuid.uuid4())  # Generate a random name for the container.
     Runner().run(['docker', 'run', '-t', '-d', '--rm', '--name',
         name, 'centos:7'])
@@ -167,10 +167,7 @@ def test_distribution_sub(setup_packages):
     assert result[0] == p1v11
 
 
-@skip_if_no_docker_engine
 def test_tracer(docker_container):
-    skip_if_no_network()
-
     # Test setup
     resource = DockerContainer(docker_container)
     resource.connect()
@@ -199,10 +196,7 @@ def test_tracer(docker_container):
     assert packages['/usr/bin/ls']['packager'].startswith('CentOS BuildSystem')
 
 
-@skip_if_no_docker_engine
 def test_distribution(docker_container, centos_spec):
-    skip_if_no_network()
-
     # Test setup
     resource = DockerContainer(docker_container)
     resource.connect()

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -14,11 +14,11 @@ from ...cmd import Runner
 # from ...distributions.singularity import SingularityDistribution
 # from ...distributions.singularity import SingularityImage
 from ...distributions.singularity import SingularityTracer
-from ...tests.utils import skip_if_no_singularity, skip_if_no_network
+from ...tests.skip import mark
 
 
-@skip_if_no_network
-@skip_if_no_singularity
+@mark.skipif_no_network
+@mark.skipif_no_singularity
 def test_singularity_trace():
 
     # Download and set up singularity image file

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -18,9 +18,9 @@ import logging
 from reproman.cmd import Runner
 from reproman.utils import chpwd
 from reproman.utils import on_linux
+from reproman.utils import swallow_logs
 from reproman.tests.utils import create_pymodule
 from reproman.tests.utils import skip_if_no_network, assert_is_subset_recur
-from reproman.tests.utils import swallow_logs
 from reproman.distributions.venv import VenvDistribution
 from reproman.distributions.venv import VenvEnvironment
 from reproman.distributions.venv import VenvPackage

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -20,7 +20,8 @@ from reproman.utils import chpwd
 from reproman.utils import on_linux
 from reproman.utils import swallow_logs
 from reproman.tests.utils import create_pymodule
-from reproman.tests.utils import skip_if_no_network, assert_is_subset_recur
+from reproman.tests.utils import assert_is_subset_recur
+from reproman.tests.skip import skipif
 from reproman.distributions.venv import VenvDistribution
 from reproman.distributions.venv import VenvEnvironment
 from reproman.distributions.venv import VenvPackage
@@ -30,8 +31,8 @@ PY_VERSION = "python{v.major}.{v.minor}".format(v=sys.version_info)
 
 
 @pytest.fixture(scope="session")
-@skip_if_no_network
 def venv_test_dir():
+    skipif.no_network()
     dirs = AppDirs('reproman')
     test_dir = os.path.join(dirs.user_cache_dir, 'venv_test')
     if os.path.exists(test_dir):

--- a/reproman/interface/tests/test_execute.py
+++ b/reproman/interface/tests/test_execute.py
@@ -22,17 +22,14 @@ from reproman.api import execute
 from reproman.formats.reproman import RepromanProvenance
 from reproman.utils import swallow_outputs
 from reproman.interface.execute import TracedCommand
-from reproman.support.external_versions import external_versions
 from ...resource.base import ResourceManager
 from ...tests.utils import assert_is_subset_recur
-from ...tests.utils import skip_if_no_apt_cache
-from ...tests.utils import skip_if_no_network
-from ...tests.utils import skip_ssh
+from ...tests.skip import mark
 from ...tests.fixtures import get_docker_fixture
 from ...consts import TEST_SSH_DOCKER_DIGEST
 
 
-docker_container = skip_ssh(get_docker_fixture)(
+docker_container = get_docker_fixture(
     TEST_SSH_DOCKER_DIGEST,
     name='testing-container',
     scope='module',
@@ -40,6 +37,7 @@ docker_container = skip_ssh(get_docker_fixture)(
 )
 
 
+@mark.skipif_no_ssh
 def test_execute_interface(docker_container):
 
     with patch('reproman.resource.ResourceManager._get_inventory') as get_inventory:
@@ -95,6 +93,7 @@ def trace_info(tmpdir_factory):
             "class": cls}
 
 
+@mark.skipif_no_ssh
 def test_trace_docker(docker_container, trace_info):
     with patch("reproman.resource.ResourceManager._get_inventory") as get_inv:
         config = {"status": "running",
@@ -118,12 +117,8 @@ def test_trace_docker(docker_container, trace_info):
 
 
 @pytest.mark.integration
-# Avoiding skip_if_no_network and skip_if_no_apt_cache because it leads to a
-# TypeError under Python 2.
-@pytest.mark.skipif(os.environ.get('REPROMAN_TESTS_NONETWORK'),
-                    reason="No network")
-@pytest.mark.skipif("cmd:apt-cache" not in external_versions,
-                    reason="No apt-cache")
+@mark.skipif_no_network
+@mark.skipif_no_apt_cache
 def test_trace_local(trace_info):
     with patch("reproman.resource.ResourceManager._get_inventory") as get_inv:
         config = {"status": "running",

--- a/reproman/interface/tests/test_retrace.py
+++ b/reproman/interface/tests/test_retrace.py
@@ -13,7 +13,8 @@ from reproman.formats import Provenance
 import logging
 
 from reproman.utils import swallow_logs, swallow_outputs, make_tempfile
-from reproman.tests.utils import assert_in, skip_if_no_apt_cache
+from reproman.tests.utils import assert_in
+from reproman.tests.skip import mark
 
 from ..retrace import identify_distributions
 
@@ -42,7 +43,7 @@ def test_retrace_to_output_file(reprozip_spec2):
         assert len(provenance.get_distributions()) == 1
 
 
-@skip_if_no_apt_cache
+@mark.skipif_no_apt_cache
 def test_retrace_normalize_paths():
     # Retrace should normalize paths before passing them to tracers.
     with swallow_outputs() as cm:

--- a/reproman/interface/tests/test_sequence.py
+++ b/reproman/interface/tests/test_sequence.py
@@ -17,9 +17,9 @@ import yaml
 
 from reproman.cmdline.main import main
 from reproman.cmd import Runner
+from reproman.utils import swallow_logs
 from reproman.resource.base import ResourceManager
 from reproman.support.exceptions import CommandError
-from reproman.tests.utils import swallow_logs
 
 
 def test_create_start_stop(tmpdir):

--- a/reproman/resource/singularity.py
+++ b/reproman/resource/singularity.py
@@ -39,7 +39,7 @@ class Singularity(Resource):
     type = attrib(default='singularity')
 
     status = attrib()
-    _runner = attrib()
+    _runner = Runner()
 
     def connect(self):
         """

--- a/reproman/resource/singularity.py
+++ b/reproman/resource/singularity.py
@@ -15,6 +15,7 @@ from shlex import quote as shlex_quote
 from ..cmd import Runner
 from ..dochelpers import borrowdoc
 from ..support.exceptions import CommandError
+from ..support.external_versions import external_versions
 from .session import POSIXSession, Session
 from .base import Resource
 from ..utils import attrib
@@ -45,14 +46,12 @@ class Singularity(Resource):
         """
         Open a connection to the environment.
         """
-        self._runner = Runner()
-
-        # Make sure singularity is installed
-        stdout, _ = self._runner.run(['singularity', '--version'])
-        if stdout.startswith('2.2') or stdout.startswith('2.3'):
+        version = external_versions["cmd:singularity"]
+        if version is None or version < "2.4":
+            msg = "Found version {}".format(version) if version else ""
             # Running singularity instances and managing them didn't happen
             # until version 2.4. See: https://singularity.lbl.gov/archive/
-            raise CommandError(msg="Singularity version >= 2.4 required.")
+            raise CommandError(msg="Singularity version >= 2.4 required." + msg)
 
         # Get instance info if we have one running.
         info = self.get_instance_info()

--- a/reproman/resource/tests/test_docker_container.py
+++ b/reproman/resource/tests/test_docker_container.py
@@ -12,7 +12,8 @@ from mock import patch, MagicMock, call
 
 from ...utils import merge_dicts
 from ...utils import swallow_logs
-from ...tests.utils import assert_in, skip_if_no_docker_engine
+from ...tests.utils import assert_in
+from ...tests.skip import mark
 from ..base import ResourceManager
 from ...support.exceptions import ResourceError
 from ...consts import TEST_SSH_DOCKER_DIGEST
@@ -165,13 +166,13 @@ def test_setup_ubuntu(setup_ubuntu):
     assert setup_ubuntu['container_id']
 
 
-@skip_if_no_docker_engine
+@mark.skipif_no_docker_engine
 def test_engine_exits():
     assert DockerContainer.is_engine_running()
     assert not DockerContainer.is_engine_running(base_url='foo')
 
 
-@skip_if_no_docker_engine
+@mark.skipif_no_docker_engine
 def test_container_exists(setup_ubuntu):
     assert DockerContainer.is_container_running(setup_ubuntu['name'])
     assert not DockerContainer.is_container_running('foo')

--- a/reproman/resource/tests/test_session.py
+++ b/reproman/resource/tests/test_session.py
@@ -24,14 +24,12 @@ from ..shell import ShellSession
 from ..singularity import Singularity, SingularitySession, \
     PTYSingularitySession
 from ..ssh import SSHSession, PTYSSHSession
-from ...tests.utils import skip_ssh
+from ...tests.skip import mark
 from ...tests.fixtures import get_docker_fixture
 from ...consts import TEST_SSH_DOCKER_DIGEST
 
 
-# Note: due to skip_ssh right here, it would skip the entire module with
-# all the tests here if no ssh testing is requested
-testing_container = skip_ssh(get_docker_fixture)(
+testing_container = get_docker_fixture(
     TEST_SSH_DOCKER_DIGEST,
     name='testing-container',
     portmaps={
@@ -251,7 +249,7 @@ def resource_session(request):
         yield request.param()
 
 
-
+@mark.skipif_no_ssh
 def test_session_abstract_methods(testing_container, resource_session,
         resource_test_dir):
 

--- a/reproman/resource/tests/test_singularity.py
+++ b/reproman/resource/tests/test_singularity.py
@@ -19,7 +19,8 @@ import logging
 import re
 from ..singularity import Singularity, SingularitySession
 from ...tests.utils import skip_if_no_singularity, skip_if_no_network, \
-    swallow_logs, assert_in
+    assert_in
+from ...utils import swallow_logs
 
 
 @skip_if_no_network

--- a/reproman/resource/tests/test_singularity.py
+++ b/reproman/resource/tests/test_singularity.py
@@ -18,13 +18,13 @@ import tempfile
 import logging
 import re
 from ..singularity import Singularity, SingularitySession
-from ...tests.utils import skip_if_no_singularity, skip_if_no_network, \
-    assert_in
+from ...tests.utils import assert_in
+from ...tests.skip import mark
 from ...utils import swallow_logs
 
 
-@skip_if_no_network
-@skip_if_no_singularity
+@mark.skipif_no_network
+@mark.skipif_no_singularity
 def test_singularity_resource_class():
 
     # Set working directory to a scratch directory since we will be creating

--- a/reproman/resource/tests/test_ssh.py
+++ b/reproman/resource/tests/test_ssh.py
@@ -18,14 +18,16 @@ from pytest import raises
 
 from ...utils import merge_dicts
 from ...utils import swallow_logs
-from ...tests.utils import assert_in, skip_ssh
+from ...tests.utils import assert_in
+from ...tests.skip import mark
 from ..base import ResourceManager
 from reproman.tests.fixtures import get_docker_fixture
 from ...consts import TEST_SSH_DOCKER_DIGEST
 
-# Note: due to skip_ssh right here, it would skip the entire module with
-# all the tests here if no ssh testing is requested
-setup_ssh = skip_ssh(get_docker_fixture)(
+# Skip entire module if no SSH is available.
+pytestmark = mark.skipif_no_ssh
+
+setup_ssh = get_docker_fixture(
     TEST_SSH_DOCKER_DIGEST,
     portmaps={
         49000: 22

--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -82,6 +82,15 @@ def _get_singularity_version():
     return _runner.run(["singularity", "--version"])[0].split("-")[0]
 
 
+def _get_svn_version():
+    """Return version of available SVN."""
+    # Example output:
+    #
+    # svn, version 1.9.5 (r1770682)
+    # [...]
+    return _runner.run(["svn", "--version"])[0].split()[2]
+
+
 class ExternalVersions(object):
     """Helper to figure out/use versions of the externals (modules, cmdline tools, etc).
 
@@ -103,6 +112,7 @@ class ExternalVersions(object):
         'cmd:git': _get_git_version,
         'cmd:singularity': _get_singularity_version,
         'cmd:system-ssh': _get_system_ssh_version,
+        'cmd:svn': _get_svn_version,
         'cmd:apt-cache': _get_apt_cache_version
     }
     INTERESTING = (

--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -76,6 +76,12 @@ def _get_system_ssh_version():
         return None
 
 
+def _get_singularity_version():
+    """Return version of available singularity."""
+    # example output: "2.6.1-dist"
+    return _runner.run(["singularity", "--version"])[0].split("-")[0]
+
+
 class ExternalVersions(object):
     """Helper to figure out/use versions of the externals (modules, cmdline tools, etc).
 
@@ -95,6 +101,7 @@ class ExternalVersions(object):
     CUSTOM = {
         'cmd:annex': _get_annex_version,
         'cmd:git': _get_git_version,
+        'cmd:singularity': _get_singularity_version,
         'cmd:system-ssh': _get_system_ssh_version,
         'cmd:apt-cache': _get_apt_cache_version
     }

--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -54,9 +54,11 @@ def _get_git_version():
     """Return version of available git"""
     return _runner.run('git version'.split())[0].split()[-1]
 
+
 def _get_apt_cache_version():
-    """Return version of available git"""
+    """Return version of available apt-cache."""
     return _runner.run('apt-cache -v'.split())[0].split()[1]
+
 
 def _get_system_ssh_version():
     """Return version of ssh available system-wide

--- a/reproman/support/tests/test_external_versions.py
+++ b/reproman/support/tests/test_external_versions.py
@@ -22,9 +22,8 @@ from ..exceptions import OutdatedExternalDependency, MissingExternalDependency
 from ...tests.utils import (
     with_tempfile,
     create_tree,
-    swallow_logs,
 )
-
+from ...utils import swallow_logs
 import pytest
 from mock import patch
 

--- a/reproman/support/tests/test_globbedpaths.py
+++ b/reproman/support/tests/test_globbedpaths.py
@@ -15,10 +15,10 @@ import logging
 from mock import patch
 import os.path as op
 
+from reproman.utils import swallow_logs
 from reproman.support.globbedpaths import GlobbedPaths
 from reproman.tests.utils import assert_in
 from reproman.tests.utils import eq_
-from reproman.tests.utils import swallow_logs
 from reproman.tests.utils import with_tree
 
 

--- a/reproman/tests/fixtures.py
+++ b/reproman/tests/fixtures.py
@@ -14,7 +14,7 @@ import tempfile
 import pytest
 from .constants import REPROMAN_CFG_PATH
 from reproman.cmd import Runner
-from reproman.tests.utils import skip_if_no_network, skip_if_no_svn
+from reproman.tests.skip import skipif
 from reproman.utils import chpwd
 
 
@@ -67,7 +67,7 @@ def get_docker_fixture(image, portmaps={}, name=None,
         on teardown, this fixture stops the docker container it started
         """
 
-        skip_if_no_network()
+        skipif.no_network()
         args = ['docker',
                 'run',
                 '-d',
@@ -188,7 +188,7 @@ def svn_repo_fixture(kind='default', scope='function'):
     """
     @pytest.fixture(scope=scope)
     def fixture():
-        skip_if_no_svn()
+        skipif.no_svn()
         repo_name = 'svnrepo'
         tmpdir = os.path.realpath(tempfile.mkdtemp(prefix='reproman-tests-'))
         root_dir = os.path.join(tmpdir, repo_name)

--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -42,14 +42,66 @@ Doing that will make the skip condition available in two places:
 now be `mark.skipif_windows` and `skipif.windows`.
 """
 import abc
+import os
+
 import pytest
+
+from reproman.resource.docker_container import DockerContainer
+from reproman.support.external_versions import external_versions
+from reproman.utils import on_windows
 
 # Condition functions
 #
 # To create a new condition, (1) add a condition function and (2) add that
 # function to CONDITION_FNS.
 
+
+def no_apt_cache():
+    return ("apt-cache not available",
+            not external_versions["cmd:apt-cache"])
+
+
+def no_docker_engine():
+    return ("No Docker",
+            not DockerContainer.is_engine_running())
+
+
+def no_network():
+    return ("no network settings",
+            os.environ.get('REPROMAN_TESTS_NONETWORK'))
+
+
+def no_singularity():
+    return ("singularity not available",
+            not external_versions["cmd:singularity"])
+
+
+def no_ssh():
+    if on_windows:
+        reason = "no ssh on windows"
+    else:
+        reason = "no ssh (REPROMAN_TESTS_SSH unset)"
+    return (reason,
+            on_windows or not os.environ.get('REPROMAN_TESTS_SSH'))
+
+
+def no_svn():
+    return ("subversion not available",
+            not external_versions["cmd:svn"])
+
+
+def windows():
+    return "on windows", on_windows
+
+
 CONDITION_FNS = [
+    no_apt_cache,
+    no_docker_engine,
+    no_network,
+    no_singularity,
+    no_ssh,
+    no_svn,
+    windows,
 ]
 
 # Entry points: skipif and mark

--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -48,7 +48,7 @@ import pytest
 
 from reproman.resource.docker_container import DockerContainer
 from reproman.support.external_versions import external_versions
-from reproman.utils import on_windows
+from reproman.utils import on_windows as _on_windows
 
 # Condition functions
 #
@@ -77,12 +77,12 @@ def no_singularity():
 
 
 def no_ssh():
-    if on_windows:
+    if _on_windows:
         reason = "no ssh on windows"
     else:
         reason = "no ssh (REPROMAN_TESTS_SSH unset)"
     return (reason,
-            on_windows or not os.environ.get('REPROMAN_TESTS_SSH'))
+            _on_windows or not os.environ.get('REPROMAN_TESTS_SSH'))
 
 
 def no_svn():
@@ -90,8 +90,8 @@ def no_svn():
             not external_versions["cmd:svn"])
 
 
-def windows():
-    return "on windows", on_windows
+def on_windows():
+    return "on windows", _on_windows
 
 
 CONDITION_FNS = [
@@ -101,7 +101,7 @@ CONDITION_FNS = [
     no_singularity,
     no_ssh,
     no_svn,
-    windows,
+    on_windows,
 ]
 
 # Entry points: skipif and mark

--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -1,0 +1,117 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the reproman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+"""Define `skipif` and `mark` namespaces for custom pytest skippers.
+
+There are two main ways to skip in pytest:
+
+  * decorating a test function, such as
+
+        @pytest.mark.skip(sys.platform.startswith("win"), reason="on windows")
+        def test_func():
+            [...]
+
+  * skipping inline, such as
+
+        def test_func():
+            if sys.platform.startswith("win"):
+                pytest.skip("on Windows")
+            [...]
+
+This module provides a mechanism to register a reason and condition as both a
+decorator and an inline function:
+
+  * Within this module, create a condition function that returns a tuple of the
+    form (REASON, COND). REASON is a str that will be shown as the reason for
+    the skip, and COND is a boolean indicating if the test should be skipped.
+
+    For example
+
+    def windows():
+        return "on windows", sys.platform.startswith("win")
+
+  * Then add the above function to CONDITION_FNS.
+
+Doing that will make the skip condition available in two places:
+`mark.skipif_NAME` and `skipif.NAME`. So, for the above example, there would
+now be `mark.skipif_windows` and `skipif.windows`.
+"""
+import abc
+import pytest
+
+# Condition functions
+#
+# To create a new condition, (1) add a condition function and (2) add that
+# function to CONDITION_FNS.
+
+CONDITION_FNS = [
+]
+
+# Entry points: skipif and mark
+
+
+class Namespace(object, metaclass=abc.ABCMeta):
+    """Provide namespace skip conditions in CONDITION_FNS.
+    """
+
+    fns = {c.__name__: c for c in CONDITION_FNS}
+
+    @abc.abstractmethod
+    def attr_value(self, condition_func):
+        """Given a condition function, return an attribute value.
+        """
+
+    def __getattr__(self, item):
+        try:
+            condfn = self.fns[item]
+        except KeyError:
+            raise AttributeError(item) from None
+        return self.attr_value(condfn)
+
+
+class SkipIf(Namespace):
+    """Namespace for inline variants of the condition functions.
+
+    Each condition is available under an attribute with the same name as the
+    condition function name.
+    """
+
+    def attr_value(self, condition_func):
+        def fn():
+            reason, cond = condition_func()
+            if cond:
+                pytest.skip(reason, allow_module_level=True)
+        return fn
+
+
+skipif = SkipIf()
+
+
+class Mark(Namespace):
+    """Namespace for mark variants of the condition functions.
+
+    Each condition is available under an attribute "skipif_NAME", where NAME is
+    the condition function name.
+    """
+
+    def attr_value(self, condition_func):
+        reason, cond = condition_func()
+        return pytest.mark.skipif(cond, reason=reason)
+
+    def __getattr__(self, item):
+        if item.startswith("skipif_"):
+            try:
+                return super(Mark, self).__getattr__(item[len("skipif_"):])
+            except AttributeError:
+                # Fall back to the original item name so that the attribute
+                # error message doesn't confusingly drop "skipif_".
+                pass
+        return super(Mark, self).__getattr__(item)
+
+
+mark = Mark()

--- a/reproman/tests/test_cmd.py
+++ b/reproman/tests/test_cmd.py
@@ -22,9 +22,13 @@ from .utils import ok_, eq_, assert_is, assert_equal, assert_false, \
 from ..cmd import Runner, link_file_load
 from ..support.exceptions import CommandError
 from ..support.protocol import DryRunProtocol
-from .utils import with_tempfile, assert_cwd_unchanged, \
-    swallow_outputs, swallow_logs, \
-    on_linux, on_osx, on_windows
+from .utils import assert_cwd_unchanged
+from .utils import with_tempfile
+from ..utils import on_linux
+from ..utils import on_osx
+from ..utils import on_windows
+from ..utils import swallow_logs
+from ..utils import swallow_outputs
 
 
 @assert_cwd_unchanged

--- a/reproman/tests/test_protocols.py
+++ b/reproman/tests/test_protocols.py
@@ -22,7 +22,7 @@ from ..support.protocol import DryRunProtocol, DryRunExternalsProtocol, \
     ProtocolInterface
 from ..cmd import Runner
 from .utils import with_tempfile
-from .utils import swallow_logs
+from ..utils import swallow_logs
 
 
 @with_tempfile

--- a/reproman/tests/test_skip.py
+++ b/reproman/tests/test_skip.py
@@ -1,0 +1,25 @@
+# emacs: -*- mode: python; py-indent-offset: 4; tab-width: 4; indent-tabs-mode: nil -*-
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the reproman package for the
+#   copyright and license terms.
+#
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+
+from mock import patch
+
+import pytest
+
+from reproman.tests.skip import mark
+from reproman.tests.skip import skipif
+
+
+def test_skipif_unknown_attribute():
+    with pytest.raises(AttributeError):
+        skipif.youdontknowme
+
+
+def test_mark_skipif_unknown_attribute():
+    with pytest.raises(AttributeError):
+        mark.skipif_youdontknowme

--- a/reproman/tests/test_skip.py
+++ b/reproman/tests/test_skip.py
@@ -35,7 +35,7 @@ def test_skipif_no_ssh():
             assert 0, "Test should not have been skipped"
 
         # We skip SSH on windows even when REPROMAN_TESTS_SSH is set.
-        with patch("reproman.tests.skip.on_windows", True):
+        with patch("reproman.tests.skip._on_windows", True):
             with pytest.raises(pytest.skip.Exception):
                 skipif.no_ssh()
 

--- a/reproman/tests/test_skip.py
+++ b/reproman/tests/test_skip.py
@@ -15,6 +15,31 @@ from reproman.tests.skip import mark
 from reproman.tests.skip import skipif
 
 
+with patch.dict("os.environ", {"REPROMAN_TESTS_NONETWORK": "1"}):
+    @mark.skipif_no_network
+    def test_mark_skipif_always_skip():
+        assert False, "This test should never run"
+
+
+def test_skipif_inline():
+    with patch.dict("os.environ", {"REPROMAN_TESTS_NONETWORK": "1"}):
+        with pytest.raises(pytest.skip.Exception):
+            skipif.no_network()
+
+
+def test_skipif_no_ssh():
+    with patch.dict("os.environ", {"REPROMAN_TESTS_SSH": "1"}):
+        try:
+            skipif.no_ssh()
+        except pytest.skip.Exception as exc:
+            assert 0, "Test should not have been skipped"
+
+        # We skip SSH on windows even when REPROMAN_TESTS_SSH is set.
+        with patch("reproman.tests.skip.on_windows", True):
+            with pytest.raises(pytest.skip.Exception):
+                skipif.no_ssh()
+
+
 def test_skipif_unknown_attribute():
     with pytest.raises(AttributeError):
         skipif.youdontknowme

--- a/reproman/tests/test_tests_utils.py
+++ b/reproman/tests/test_tests_utils.py
@@ -39,7 +39,6 @@ from .utils import eq_, ok_, assert_false, ok_startswith, nok_startswith, \
 
 from .utils import ok_generator
 from .utils import assert_re_in
-from .utils import skip_if_no_network
 from .utils import run_under_dir
 from .utils import ok_file_has_content
 from .utils import without_http_proxy
@@ -411,26 +410,6 @@ def test_assert_re_in():
     assert_raises(AssertionError, assert_re_in, "", [])
 
 
-def test_skip_if_no_network():
-    cleaned_env = os.environ.copy()
-    cleaned_env.pop('REPROMAN_TESTS_NONETWORK', None)
-    # we need to run under cleaned env to make sure we actually test in both conditions
-    with patch('os.environ', cleaned_env):
-        @skip_if_no_network
-        def somefunc(a1):
-            return a1
-        eq_(somefunc.tags, ['network'])
-        with patch.dict('os.environ', {'REPROMAN_TESTS_NONETWORK': '1'}):
-            assert_raises(pytest.skip.Exception, somefunc, 1)
-        with patch.dict('os.environ', {}):
-            eq_(somefunc(1), 1)
-        # and now if used as a function, not a decorator
-        with patch.dict('os.environ', {'REPROMAN_TESTS_NONETWORK': '1'}):
-            assert_raises(pytest.skip.Exception, skip_if_no_network)
-        with patch.dict('os.environ', {}):
-            eq_(skip_if_no_network(), None)
-
-
 @assert_cwd_unchanged
 @with_tempfile(mkdir=True)
 def test_run_under_dir(d=None):
@@ -484,18 +463,3 @@ def test_assert_is_subset_recur():
                   [3, [2]], [3, [2, 1]], [dict])
 
 
-def test_skip_ssh():
-    from .utils import skip_ssh
-
-    try:
-        @skip_ssh
-        def func(x):
-            return x + 2
-
-        with patch.dict('os.environ', {'REPROMAN_TESTS_SSH': "1"}):
-            assert func(2) == 4
-    except pytest.skip.Exception:
-        raise AssertionError("must have not skipped")
-
-    with patch.dict('os.environ', {'REPROMAN_TESTS_SSH': ""}):
-        assert_raises(pytest.skip.Exception, func, 2)

--- a/reproman/tests/test_tests_utils.py
+++ b/reproman/tests/test_tests_utils.py
@@ -29,11 +29,10 @@ from .utils import assert_in, assert_not_in, assert_true
 import pytest
 
 from ..utils import getpwd, chpwd
-
+from ..utils import swallow_logs
 from .utils import eq_, ok_, assert_false, ok_startswith, nok_startswith, \
     with_tempfile, with_tree, \
     rmtemp, OBSCURE_FILENAMES, get_most_obscure_supported_name, \
-    swallow_logs, \
     on_windows, assert_raises, assert_cwd_unchanged, serve_path_via_http, \
     ok_symlink, ok_good_symlink, ok_broken_symlink, \
     assert_is_subset_recur

--- a/reproman/tests/test_utils.py
+++ b/reproman/tests/test_utils.py
@@ -199,7 +199,7 @@ def test_getpwd_basic():
         assert_false(oschdir.called)
 
 
-@mark.skipif_windows
+@mark.skipif_on_windows
 @with_tempfile(mkdir=True)
 @assert_cwd_unchanged
 def test_getpwd_symlink(tdir=None):

--- a/reproman/tests/test_utils.py
+++ b/reproman/tests/test_utils.py
@@ -42,6 +42,7 @@ from ..utils import partition
 from ..utils import make_tempfile
 from ..utils import on_windows
 from ..utils import _path_
+from ..utils import to_binarystring
 from ..utils import to_unicode
 from ..utils import generate_unique_name
 from ..utils import PathRoot, is_subpath
@@ -50,10 +51,15 @@ from ..utils import merge_dicts
 
 from .utils import ok_, eq_, assert_false, assert_equal, assert_true
 
-from .utils import with_tempfile, assert_in, with_tree, to_binarystring, \
-    is_unicode, is_binarystring, CommandError
-from .utils import assert_cwd_unchanged, skip_if_on_windows
-from .utils import assure_dict_from_str, assure_list_from_str
+from ..utils import is_unicode
+from ..utils import is_binarystring
+from ..utils import CommandError
+from .utils import assert_cwd_unchanged
+from .utils import assert_in
+from .utils import with_tree
+from .utils import with_tempfile
+from .utils import skip_if_on_windows
+from ..utils import assure_dict_from_str, assure_list_from_str
 from .utils import ok_generator
 from .utils import assert_not_in
 from .utils import assert_raises

--- a/reproman/tests/test_utils.py
+++ b/reproman/tests/test_utils.py
@@ -58,7 +58,7 @@ from .utils import assert_cwd_unchanged
 from .utils import assert_in
 from .utils import with_tree
 from .utils import with_tempfile
-from .utils import skip_if_on_windows
+from .skip import mark
 from ..utils import assure_dict_from_str, assure_list_from_str
 from .utils import ok_generator
 from .utils import assert_not_in
@@ -199,7 +199,7 @@ def test_getpwd_basic():
         assert_false(oschdir.called)
 
 
-@skip_if_on_windows
+@mark.skipif_windows
 @with_tempfile(mkdir=True)
 @assert_cwd_unchanged
 def test_getpwd_symlink(tdir=None):

--- a/reproman/tests/utils.py
+++ b/reproman/tests/utils.py
@@ -19,7 +19,6 @@ import logging
 from mock import patch
 import pytest
 
-from reproman.support.external_versions import external_versions
 from http.server import SimpleHTTPRequestHandler
 from http.server import HTTPServer
 
@@ -34,7 +33,6 @@ from ..utils import on_windows
 from ..utils import optional_args
 from ..utils import rmtemp
 from ..dochelpers import borrowkwargs
-from ..resource.docker_container import DockerContainer
 
 # temp paths used by clones
 _TEMP_PATHS_CLONES = set()
@@ -347,129 +345,6 @@ def with_tempfile(t, **tkwargs):
 
     return newfunc
 
-
-def skip_if_no_network(func=None):
-    """Skip test completely in NONETWORK settings
-
-    If not used as a decorator, and just a function, could be used at the module level
-    """
-
-    def check_and_raise():
-        if os.environ.get('REPROMAN_TESTS_NONETWORK'):
-            pytest.skip("Skipping since no network settings",
-                        allow_module_level=True)
-
-    if func:
-        @wraps(func)
-        def newfunc(*args, **kwargs):
-            check_and_raise()
-            return func(*args, **kwargs)
-        # right away tag the test as a networked test
-        tags = getattr(newfunc, 'tags', [])
-        newfunc.tags = tags + ['network']
-        return newfunc
-    else:
-        check_and_raise()
-
-
-def skip_if_on_windows(func):
-    """Skip test completely under Windows
-    """
-    @wraps(func)
-    def newfunc(*args, **kwargs):
-        if on_windows:
-            pytest.skip("Skipping on Windows", allow_module_level=True)
-        return func(*args, **kwargs)
-    return newfunc
-
-
-def skip_if_no_apt_cache(func=None):
-    """Skip test completely if apt is unavailable
-
-    If not used as a decorator, and just a function, could be used at the module level
-    """
-
-    def check_and_raise():
-        if not external_versions["cmd:apt-cache"]:
-            pytest.skip("Skipping since apt-cache is not available",
-                        allow_module_level=True)
-
-    if func:
-        @wraps(func)
-        def newfunc(*args, **kwargs):
-            check_and_raise()
-            return func(*args, **kwargs)
-        return newfunc
-    else:
-        check_and_raise()
-
-
-def skip_if_no_svn():
-    if not external_versions["cmd:svn"]:
-        pytest.skip('subversion is not installed',
-                    allow_module_level=True)
-
-
-def skip_ssh(func=None):
-    """Skips SSH tests if on windows or if environment variable
-    REPROMAN_TESTS_SSH was not set
-    """
-
-    def check_and_raise():
-        if not os.environ.get('REPROMAN_TESTS_SSH'):
-            pytest.skip("Run this test by setting REPROMAN_TESTS_SSH",
-                        allow_module_level=True)
-
-    if func:
-        @wraps(func)
-        def newfunc(*args, **kwargs):
-            if on_windows:
-                pytest.skip("SSH currently not available on windows.",
-                            allow_module_level=True)
-            check_and_raise()
-            return func(*args, **kwargs)
-        return newfunc
-    else:
-        check_and_raise()
-
-
-def skip_if_no_docker_engine(func):
-    """Test decorator that will skip a test if a Docker engine can't be found.
-
-    Returns
-    -------
-    func
-        Decorator function
-
-    Raises
-    ------
-    SkipTest
-    """
-    if not DockerContainer.is_engine_running():
-        pytest.skip("Docker not found, skipping test {}".format(func.__name__),
-                    allow_module_level=True)
-    return func
-
-
-def skip_if_no_singularity(func):
-    """Test decorator that will skip a test if the singularity executable is
-    not found.
-    
-    Returns
-    -------
-    func
-        Decorator function
-    """
-    version = external_versions["cmd:singularity"]
-    if version is None:
-        msg = "Singularity not installed, skipping test {}"
-        pytest.skip(msg.format(func.__name__), allow_module_level=True)
-    elif version < "2.4":
-        # Running singularity instances and managing them didn't happen
-        # until version 2.4. See: https://singularity.lbl.gov/archive/
-        msg = "Singularity version >= 2.4 required, skipping test {}"
-        pytest.skip(msg.format(func.__name__), allow_module_level=True)
-    return func
 
 @optional_args
 def assert_cwd_unchanged(func, ok_to_chdir=False):

--- a/reproman/tests/utils.py
+++ b/reproman/tests/utils.py
@@ -433,33 +433,6 @@ def skip_ssh(func=None):
         check_and_raise()
 
 
-def skip_if_no_docker_container(container_name='testing-container'):
-    """Test decorator that will skip a test if the Docker container the test is
-    going to connect to is not running in the Docker engine.
-
-    Parameters
-    ----------
-    container_name : str
-        Name of the container that needs to be running for the test to work.
-
-    Returns
-    -------
-    func
-        Decorator function
-
-    Raises
-    ------
-    SkipTest
-    """
-    def decorator(func):
-        if not DockerContainer.is_container_running(container_name):
-            pytest.skip("Docker container '{}' not running, "
-                        "skipping test  {}".format(container_name, func.__name__),
-                        allow_module_level=True)
-        return func
-    return decorator
-
-
 def skip_if_no_docker_engine(func):
     """Test decorator that will skip a test if a Docker engine can't be found.
 

--- a/reproman/tests/utils.py
+++ b/reproman/tests/utils.py
@@ -10,6 +10,7 @@
 
 import inspect
 import os
+import sys
 import re
 import tempfile
 import platform
@@ -25,7 +26,13 @@ from http.server import HTTPServer
 from functools import wraps
 from os.path import exists, realpath, join as opj
 
-from ..utils import *
+from ..utils import chpwd
+from ..utils import get_tempfile_kwargs
+from ..utils import getpwd
+from ..utils import make_tempfile
+from ..utils import on_windows
+from ..utils import optional_args
+from ..utils import rmtemp
 from ..dochelpers import borrowkwargs
 from ..resource.docker_container import DockerContainer
 

--- a/reproman/tests/utils.py
+++ b/reproman/tests/utils.py
@@ -25,7 +25,6 @@ from http.server import HTTPServer
 from functools import wraps
 from os.path import exists, realpath, join as opj
 
-from ..cmd import Runner
 from ..utils import *
 from ..dochelpers import borrowkwargs
 from ..resource.docker_container import DockerContainer
@@ -488,14 +487,11 @@ def skip_if_no_singularity(func):
     func
         Decorator function
     """
-    # Make sure singularity is installed
-    try:
-        stdout, _ = Runner().run(['singularity', '--version'])
-    except Exception:
+    version = external_versions["cmd:singularity"]
+    if version is None:
         msg = "Singularity not installed, skipping test {}"
         pytest.skip(msg.format(func.__name__), allow_module_level=True)
-
-    if stdout.startswith('2.2') or stdout.startswith('2.3'):
+    elif version < "2.4":
         # Running singularity instances and managing them didn't happen
         # until version 2.4. See: https://singularity.lbl.gov/archive/
         msg = "Singularity version >= 2.4 required, skipping test {}"

--- a/reproman/tests/utils.py
+++ b/reproman/tests/utils.py
@@ -398,16 +398,9 @@ def skip_if_no_apt_cache(func=None):
 
 
 def skip_if_no_svn():
-    runner = Runner()
-    try:
-        # will raise OSError(errno=2) if the command is not found
-        runner.run(['svnadmin', '--help'])
-        runner.run(['svn', '--help'])
-    except OSError as exc:
-        if exc.errno == 2:
-            pytest.skip('subversion is not installed',
-                        allow_module_level=True)
-    return
+    if not external_versions["cmd:svn"]:
+        pytest.skip('subversion is not installed',
+                    allow_module_level=True)
 
 
 def skip_ssh(func=None):


### PR DESCRIPTION
The goal of this PR is to make it easier to add custom skip functions.  (I started looking at this when working on adding a custom "skip if condor not installed" function.)  I've added a new module tests/skip.py that defines two entry points, `skipif` and `mark`.  These provide access to all the conditions.  For example, for the no network case, it'd look something like

```python
@mark.skipif_no_network
def test_some_network():
    pass
```

or

```python
def test_some_thing():
    [...]
    if [some on-the-fly reason to skip]:
        skipif.no_network()
```

Those `skipif.*` and `mark.skipif_*` functions above are defined based on a single function, which is  member of the list of functions in `skip.CONDITION_FNS`:

```python
def no_network():
    return ("no network settings",
            os.environ.get('REPROMAN_TESTS_NONETWORK'))
```

There are some clean-up and preparatory commits aside from the commits that define the interface above.  The most notable ones add SVN and Singularity to `external_versions`.
