### PR TITLE
CLN: setup.py: Don't list mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ requires = {
         'appdirs',
         'attrs>=16.3.0',
         'humanize',
-        'mock',  # mock is also used for auto.py, not only for testing
         'pyyaml',
         'tqdm',
         'fabric>=2.3.1',
@@ -79,7 +78,6 @@ requires = {
         'rdflib',
     ],
     'tests': [
-        'mock',
         'pytest>=3.3.0',
     ]
 }


### PR DESCRIPTION
Our minimum Python version is now 3.4, and mock is included in the
standard library as Python 3.3.