### PR TITLE
TST: Demote some log errors

### DIFF
--- a/reproman/distributions/tests/test_redhat.py
+++ b/reproman/distributions/tests/test_redhat.py
@@ -27,7 +27,8 @@ def docker_container():
     skipif.no_docker_engine()
     name = str(uuid.uuid4())  # Generate a random name for the container.
     Runner().run(['docker', 'run', '-t', '-d', '--rm', '--name',
-        name, 'centos:7'])
+                  name, 'centos:7'],
+                 expect_stderr=True)
     yield name
     Runner().run(['docker', 'stop', name])
 

--- a/reproman/distributions/tests/test_vcs.py
+++ b/reproman/distributions/tests/test_vcs.py
@@ -6,6 +6,7 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+from functools import partial
 import os
 import os.path as op
 
@@ -368,7 +369,7 @@ def test_git_install_detached(traced_repo_copy, tmpdir):
 
     # We detach if there is no recorded branch.
     git_pkg.branch = None
-    runner(["git", "checkout", "master"])
+    runner(["git", "checkout", "master"], expect_stderr=True)
     install(git_dist, install_dir)
     assert current_hexsha(runner) == git_pkg.hexsha
     assert not current_branch(runner)
@@ -400,6 +401,7 @@ def test_git_install_checkout(traced_repo_copy, tmpdir):
 
     install_dir = op.join(tmpdir, "installed")
     runner = GitRunner(cwd=install_dir)
+    run = partial(runner.run, expect_stderr=True)
 
     # Installing to a non-existing location will be more aggressive, creating a
     # new branch at the recorded hexsha rather than just detaching there.
@@ -410,14 +412,14 @@ def test_git_install_checkout(traced_repo_copy, tmpdir):
 
     # If the recorded branch is in the existing installation repo and has the
     # same hexsha, we check it out.
-    runner(["git", "checkout", "master"])
-    runner(["git", "branch", "--force", "other", git_pkg.hexsha])
+    run(["git", "checkout", "master"])
+    run(["git", "branch", "--force", "other", git_pkg.hexsha])
     install(git_dist, install_dir)
     assert current_hexsha(runner) == git_pkg.hexsha
     assert current_branch(runner) == "other"
     # Otherwise, we detach.
-    runner(["git", "checkout", "master"])
-    runner(["git", "branch", "--force", "other", git_pkg.hexsha + "^"])
+    run(["git", "checkout", "master"])
+    run(["git", "branch", "--force", "other", git_pkg.hexsha + "^"])
     install(git_dist, install_dir)
     assert current_hexsha(runner) == git_pkg.hexsha
     assert not current_branch(runner)

--- a/reproman/tests/fixtures.py
+++ b/reproman/tests/fixtures.py
@@ -85,7 +85,7 @@ def get_docker_fixture(image, portmaps={}, name=None,
                 args += ['-p', '%d:%d' % from_to]
                 params['port'] = from_to[0]
         args += [image]
-        stdout, _ = Runner().run(args)
+        stdout, _ = Runner().run(args, expect_stderr=True)
         params['container_id'] = container_id = stdout.strip( )
         params['custom'] = custom_params
         yield params


### PR DESCRIPTION
Clean up a few places that log expected stderr as errors.  For example, there is no need to pollute the test logs with

    [ERROR  ] stderr| Switched to branch 'master'