### PR TITLE
ls: Support limiting output to specified resources

### DIFF
--- a/reproman/interface/ls.py
+++ b/reproman/interface/ls.py
@@ -11,6 +11,8 @@
 
 __docformat__ = 'restructuredtext'
 
+from collections import OrderedDict
+
 from .base import Interface
 # import reproman.interface.base  # Needed for test patching
 from ..support.param import Parameter
@@ -52,6 +54,7 @@ class Ls(Interface):
         ui.message(template.format('RESOURCE NAME', 'TYPE', 'ID', 'STATUS'))
         ui.message(template.format('-------------', '----', '--', '------'))
 
+        results = OrderedDict()
         manager = get_manager()
         for name in sorted(manager):
             if name.startswith('_'):
@@ -74,16 +77,18 @@ class Ls(Interface):
 
                 manager.inventory[name].update({'status': resource.status})
 
+            id_ = manager.inventory[name]['id']
             msgargs = (
                 name,
                 resource.type,
-                manager.inventory[name]['id'][:id_length],
+                id_[:id_length],
                 resource.status,
             )
             ui.message(template.format(*msgargs))
-            lgr.debug('list result: {}, {}, {}, {}'.format(*msgargs))
+            results[id_] = msgargs
 
         if refresh:
             manager.save_inventory()
         else:
             ui.message('Use --refresh option to view updated status.')
+        return results

--- a/reproman/interface/tests/test_ls.py
+++ b/reproman/interface/tests/test_ls.py
@@ -9,12 +9,8 @@
 
 from mock import patch
 
+from ...api import ls
 from ...resource.base import ResourceManager
-from ...cmdline.main import main
-from ...utils import swallow_logs
-from ...tests.utils import assert_in
-
-import logging
 
 
 def mock_get_manager():
@@ -56,18 +52,17 @@ def test_ls_interface():
     """
     Test listing the resources.
     """
-
     with patch('docker.Client'), \
-            patch('reproman.interface.ls.get_manager', new=mock_get_manager), \
-            swallow_logs(new_level=logging.DEBUG) as log:
-
-        main(['ls'])
-        assert_in('list result: docker-resource-1, docker-container, 326b0fdfbf838, running', log.lines)
-        assert_in('list result: ec2-resource-1, aws-ec2, i-22221ddf096c22bb0, running', log.lines)
-        assert_in('list result: ec2-resource-2, aws-ec2, i-3333f40de2b9b8967, stopped', log.lines)
+            patch('reproman.interface.ls.get_manager', new=mock_get_manager):
+        results = ls()
+        assert "running" in results["326b0fdfbf838"]
+        assert "docker-container" in results["326b0fdfbf838"]
+        assert "i-22221ddf096c22bb0" in results
+        assert "stopped" in results["i-3333f40de2b9b8967"]
+        assert "aws-ec2" in results["i-3333f40de2b9b8967"]
 
         # Test --refresh output
-        main(['ls', '--refresh'])
-        assert_in('list result: docker-resource-1, docker-container, 326b0fdfbf838, NOT FOUND', log.lines)
-        assert_in('list result: ec2-resource-1, aws-ec2, i-22221ddf096c22bb0, CONNECTION ERROR', log.lines)
-        assert_in('list result: ec2-resource-2, aws-ec2, i-3333f40de2b9b8967, CONNECTION ERROR', log.lines)
+        results = ls(refresh=True)
+        assert "NOT FOUND" in results["326b0fdfbf838"]
+        assert "CONNECTION ERROR" in results["i-22221ddf096c22bb0"]
+        assert "CONNECTION ERROR" in results["i-3333f40de2b9b8967"]

--- a/reproman/interface/tests/test_ls.py
+++ b/reproman/interface/tests/test_ls.py
@@ -80,3 +80,10 @@ def test_ls_interface(ls_fn):
     assert "NOT FOUND" in results["326b0fdfbf838"]
     assert "CONNECTION ERROR" in results["i-22221ddf096c22bb0"]
     assert "CONNECTION ERROR" in results["i-3333f40de2b9b8967"]
+
+
+def test_ls_interface_limited(ls_fn):
+    results = ls_fn(resrefs=["326", "i-33"])
+    assert "326b0fdfbf838" in results
+    assert "i-22221ddf096c22bb0" not in results
+    assert "i-3333f40de2b9b8967" in results


### PR DESCRIPTION
```
% reproman ls
RESOURCE NAME        TYPE                 ID                  STATUS    
-------------        ----                 --                  ------    
sm                   ssh                  cdfd149d-4288-4c64- N/A       
ss                   shell                5138c6e4-35eb-11e9- available 
ubdock               docker-container     d57fbb52c704bd6b0b4 running   
Use --refresh option to view updated status.

% reproman ls ubdock
RESOURCE NAME        TYPE                 ID                  STATUS    
-------------        ----                 --                  ------    
ubdock               docker-container     d57fbb52c704bd6b0b4 running   
Use --refresh option to view updated status.

% reproman ls cdfd ss
RESOURCE NAME        TYPE                 ID                  STATUS    
-------------        ----                 --                  ------    
sm                   ssh                  cdfd149d-4288-4c64- N/A       
ss                   shell                5138c6e4-35eb-11e9- available 
Use --refresh option to view updated status.
```

---

Closes #328.