### PR TITLE
BF: Adjust mock imports

### DIFF
--- a/reproman/distributions/tests/test_conda.py
+++ b/reproman/distributions/tests/test_conda.py
@@ -10,7 +10,7 @@ import os
 import pytest
 
 import sys
-from mock import mock
+from unittest import mock
 from subprocess import call
 
 import yaml

--- a/reproman/distributions/tests/test_debian.py
+++ b/reproman/distributions/tests/test_debian.py
@@ -21,7 +21,7 @@ from reproman.distributions.debian import DebianDistribution
 
 import pytest
 
-import mock
+from unittest import mock
 
 from reproman.utils import swallow_logs
 from reproman.tests.skip import mark

--- a/reproman/distributions/tests/test_distribution.py
+++ b/reproman/distributions/tests/test_distribution.py
@@ -9,7 +9,7 @@
 from ...formats import Provenance
 
 import logging
-from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from reproman.utils import swallow_logs
 from reproman.utils import items_to_dict

--- a/reproman/distributions/tests/test_piputils.py
+++ b/reproman/distributions/tests/test_piputils.py
@@ -7,7 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-import mock
+from unittest import mock
 
 from reproman.distributions import piputils
 from reproman.tests.utils import assert_is_subset_recur

--- a/reproman/interface/tests/test_backend_parameters.py
+++ b/reproman/interface/tests/test_backend_parameters.py
@@ -7,7 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import logging
-import mock
+from unittest import mock
 from io import StringIO
 
 from reproman.api import backend_parameters

--- a/reproman/interface/tests/test_create.py
+++ b/reproman/interface/tests/test_create.py
@@ -10,7 +10,7 @@
 from collections import OrderedDict
 import logging
 import pytest
-from mock import patch, call, MagicMock
+from unittest.mock import patch, call, MagicMock
 
 from reproman.api import create
 from reproman.cmdline.main import main

--- a/reproman/interface/tests/test_delete.py
+++ b/reproman/interface/tests/test_delete.py
@@ -9,7 +9,7 @@
 from reproman.cmdline.main import main
 
 import logging
-from mock import patch, call, MagicMock
+from unittest.mock import patch, call, MagicMock
 
 from ...resource.base import ResourceManager
 from ...utils import swallow_logs

--- a/reproman/interface/tests/test_execute.py
+++ b/reproman/interface/tests/test_execute.py
@@ -10,7 +10,7 @@ from reproman.cmdline.main import main
 
 import functools
 import uuid
-from mock import patch
+from unittest.mock import patch
 import os
 import os.path as op
 import pytest

--- a/reproman/interface/tests/test_install.py
+++ b/reproman/interface/tests/test_install.py
@@ -9,7 +9,7 @@
 from reproman.cmdline.main import main
 
 import logging
-from mock import patch, call, MagicMock
+from unittest.mock import patch, call, MagicMock
 
 from ...resource.base import ResourceManager
 from ...utils import swallow_logs

--- a/reproman/interface/tests/test_login.py
+++ b/reproman/interface/tests/test_login.py
@@ -9,7 +9,7 @@
 from reproman.cmdline.main import main
 
 import logging
-from mock import patch, call, MagicMock
+from unittest.mock import patch, call, MagicMock
 
 from reproman.utils import swallow_logs
 from reproman.resource.base import ResourceManager

--- a/reproman/interface/tests/test_ls.py
+++ b/reproman/interface/tests/test_ls.py
@@ -7,7 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import contextlib
-from mock import patch
+from unittest.mock import patch
 
 import pytest
 

--- a/reproman/interface/tests/test_sequence.py
+++ b/reproman/interface/tests/test_sequence.py
@@ -12,7 +12,7 @@ import os
 import os.path as op
 import pytest
 
-from mock import patch
+from unittest.mock import patch
 import yaml
 
 from reproman.cmdline.main import main

--- a/reproman/resource/tests/test_aws_ec2.py
+++ b/reproman/resource/tests/test_aws_ec2.py
@@ -7,7 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import logging
-from mock import patch, call, MagicMock
+from unittest.mock import patch, call, MagicMock
 
 from ...utils import swallow_logs
 from ...tests.utils import assert_in

--- a/reproman/resource/tests/test_base.py
+++ b/reproman/resource/tests/test_base.py
@@ -5,7 +5,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from mock import patch
+from unittest.mock import patch
 import os.path as op
 import pytest
 

--- a/reproman/resource/tests/test_docker_container.py
+++ b/reproman/resource/tests/test_docker_container.py
@@ -7,7 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import logging
-from mock import patch, MagicMock, call
+from unittest.mock import patch, MagicMock, call
 
 from ...utils import merge_dicts
 from ...utils import swallow_logs

--- a/reproman/resource/tests/test_shell.py
+++ b/reproman/resource/tests/test_shell.py
@@ -12,7 +12,7 @@ import pytest
 import re
 import tempfile
 from pytest import raises
-from mock import patch, call
+from unittest.mock import patch, call
 
 from ...utils import merge_dicts
 from ...utils import swallow_logs

--- a/reproman/resource/tests/test_ssh.py
+++ b/reproman/resource/tests/test_ssh.py
@@ -8,7 +8,7 @@
 # Test string to read
 
 import logging
-import mock
+from unittest import mock
 import os
 import pytest
 import re

--- a/reproman/support/tests/test_external_versions.py
+++ b/reproman/support/tests/test_external_versions.py
@@ -24,7 +24,7 @@ from ...tests.utils import (
 )
 from ...utils import swallow_logs
 import pytest
-from mock import patch
+from unittest.mock import patch
 
 
 def cmp(a, b):

--- a/reproman/support/tests/test_globbedpaths.py
+++ b/reproman/support/tests/test_globbedpaths.py
@@ -12,7 +12,7 @@
 __docformat__ = 'restructuredtext'
 
 import logging
-from mock import patch
+from unittest.mock import patch
 import os.path as op
 
 from reproman.utils import swallow_logs

--- a/reproman/tests/test_cmd.py
+++ b/reproman/tests/test_cmd.py
@@ -8,7 +8,7 @@
 """Test command call wrapper
 """
 
-from mock import patch
+from unittest.mock import patch
 import os
 import sys
 import logging

--- a/reproman/tests/test_cmdline_main.py
+++ b/reproman/tests/test_cmdline_main.py
@@ -10,7 +10,7 @@
 import re
 import sys
 from io import StringIO
-from mock import patch
+from unittest.mock import patch
 import pytest
 
 import reproman

--- a/reproman/tests/test_config.py
+++ b/reproman/tests/test_config.py
@@ -6,7 +6,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from mock import patch
+from unittest.mock import patch
 from ..config import ConfigManager
 from .utils import ok_, eq_, assert_raises, assert_greater
 

--- a/reproman/tests/test_dochelpers.py
+++ b/reproman/tests/test_dochelpers.py
@@ -8,7 +8,7 @@
 """Tests for dochelpers (largely copied from PyMVPA, the same copyright)
 """
 
-from mock import patch
+from unittest.mock import patch
 
 from ..dochelpers import single_or_plural, borrowdoc, borrowkwargs
 from ..dochelpers import exc_str

--- a/reproman/tests/test_installed.py
+++ b/reproman/tests/test_installed.py
@@ -8,7 +8,8 @@
 """Test invocation of reproman utilities "as is installed"
 """
 
-from mock import patch
+from unittest.mock import patch
+
 import pytest
 from .utils import ok_startswith, eq_, \
     assert_cwd_unchanged

--- a/reproman/tests/test_log.py
+++ b/reproman/tests/test_log.py
@@ -11,7 +11,7 @@ import re
 import os.path
 from os.path import exists
 
-from mock import patch
+from unittest.mock import patch
 
 from reproman.log import LoggerHelper
 

--- a/reproman/tests/test_skip.py
+++ b/reproman/tests/test_skip.py
@@ -6,7 +6,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-from mock import patch
+from unittest.mock import patch
 
 import pytest
 

--- a/reproman/tests/test_tests_utils.py
+++ b/reproman/tests/test_tests_utils.py
@@ -24,7 +24,7 @@ from os.path import exists, basename
 
 from urllib.request import urlopen
 
-from mock import patch
+from unittest.mock import patch
 from .utils import assert_in, assert_not_in, assert_true
 import pytest
 

--- a/reproman/tests/test_utils.py
+++ b/reproman/tests/test_utils.py
@@ -15,7 +15,7 @@ import pytest
 import shutil
 import sys
 import logging
-from mock import patch
+from unittest.mock import patch
 
 from operator import itemgetter
 from os.path import dirname, normpath, pardir, basename

--- a/reproman/tests/utils.py
+++ b/reproman/tests/utils.py
@@ -15,7 +15,7 @@ import tempfile
 import platform
 import multiprocessing
 import logging
-from mock import patch
+from unittest.mock import patch
 import pytest
 
 from http.server import SimpleHTTPRequestHandler

--- a/reproman/ui/dialog.py
+++ b/reproman/ui/dialog.py
@@ -23,7 +23,7 @@ import time
 import getpass
 
 #!!! OPT adds >100ms to import time!!!
-# from mock import patch
+# from unittest.mock import patch
 from collections import deque
 from copy import copy
 
@@ -117,7 +117,7 @@ def getpass_echo(prompt='Password: ', stream=None):
         #     if out == '\n':
         #         return
         #     stream.write(out)
-        from mock import patch
+        from unittest.mock import patch
         with patch('termios.ECHO', 255**2):
             #patch.object(stream, 'write', _no_emptyline_write(stream)):
             return getpass.getpass(prompt=prompt, stream=stream)

--- a/reproman/ui/tests/test_dialog.py
+++ b/reproman/ui/tests/test_dialog.py
@@ -12,7 +12,7 @@ __docformat__ = 'restructuredtext'
 from io import StringIO
 import builtins
 
-from mock import patch
+from unittest.mock import patch
 import pytest
 
 from ...tests.utils import eq_


### PR DESCRIPTION
aa1106667 (CLN: setup.py: Don't list mock, 2019-02-26) dropped mock
from setup.py because it is part of the standard library as of Python
3.3.  However, the imports should have been adjusted because mock.py
now lives under the unittest package.  The Travis build for #379
didn't catch this, presumably because mock is already installed in the
environment.