### PR TITLE
DOC: ssh: Clean up misplaced AWS-related bits

### DIFF
--- a/reproman/resource/ssh.py
+++ b/reproman/resource/ssh.py
@@ -40,11 +40,11 @@ class SSH(Resource):
     port = attrib(
         doc="Port to connect to on remote host")
     key_filename = attrib(
-        doc="Path to SSH private key file matched with AWS key name parameter")
+        doc="Path to SSH private key file")
     user = attrib(
         doc="Username to use to log into remote environment")
 
-    id = attrib()  # EC2 instance ID
+    id = attrib()
 
     type = attrib(default='ssh')  # Resource type
 


### PR DESCRIPTION
These are presumably pastos from when the ssh resource was created.