### PR TITLE
MNT: ssh: Silence paramiko warnings

### DIFF
--- a/reproman/resource/ssh.py
+++ b/reproman/resource/ssh.py
@@ -28,6 +28,13 @@ from reproman.dochelpers import borrowdoc
 from reproman.resource.session import Session
 from ..support.exceptions import CommandError
 
+# Silence CryptographyDeprecationWarning's.
+# TODO: We should bump the required paramiko version and drop the code below
+# once paramiko cuts a release that includes
+# <https://github.com/paramiko/paramiko/pull/1379>.
+import warnings
+warnings.filterwarnings(action="ignore", module=".*paramiko.*")
+
 
 @attr.s
 class SSH(Resource):


### PR DESCRIPTION
Using paramiko currently floods our output with warnings like

  [...]/lib/python3.5/site-packages/paramiko/kex_ecdh_nist.py:39:
  CryptographyDeprecationWarning: encode_point has been deprecated on
  EllipticCurvePublicNumbers and will be removed in a future
  version. [...]

Silence these because there's nothing for us to do here besides wait
for a paramiko release that includes a fix.  Leave a comment pointing
to the currently open paramiko PR that deals with these warnings.

Closes #390.