### PR TITLE
OPT: delay imports of requests, jinja2, paramiko (et al) until used

### DIFF
--- a/reproman/distributions/debian.py
+++ b/reproman/distributions/debian.py
@@ -14,7 +14,7 @@ from datetime import datetime
 
 import attr
 from collections import defaultdict
-
+# OPT: requests is imported at the point of use
 
 import pytz
 
@@ -24,8 +24,6 @@ from reproman.utils import attrib
 from email.utils import mktime_tz, parsedate_tz
 
 import logging
-
-import requests
 
 from reproman.support.distributions.debian import \
     parse_apt_cache_show_pkgs_output, parse_apt_cache_policy_pkgs_output, \
@@ -184,6 +182,7 @@ class DebianDistribution(Distribution):
                 date.strftime("%Y%m%dT%H%M%SZ"),
                 source.codename
             )
+            import requests  # OPT
             r = requests.get(url)
             m = re.search(
                 '<a href="/archive/\w*debian/(\w+)/dists/\w+/">next change</a>',

--- a/reproman/resource/docker_container.py
+++ b/reproman/resource/docker_container.py
@@ -13,8 +13,8 @@ import dockerpty
 import io
 import json
 import os
-import requests
 import tarfile
+
 from reproman import utils
 from ..cmd import Runner
 from ..support.exceptions import CommandError, ResourceError
@@ -66,10 +66,11 @@ class DockerContainer(Resource):
         -------
         boolean
         """
+        from requests.exceptions import ConnectionError
         try:
             session = docker.Client(base_url=base_url)
             session.info()
-        except (requests.exceptions.ConnectionError,
+        except (ConnectionError,
                 docker.errors.DockerException):
             return False
         return True

--- a/reproman/support/jobs/template.py
+++ b/reproman/support/jobs/template.py
@@ -12,7 +12,8 @@
 import os.path as op
 import logging
 
-import jinja2
+# jinja2 is imported at the point of use for faster startup
+
 from shlex import quote as shlex_quote
 
 lgr = logging.getLogger("reproman.support.jobs.template")
@@ -31,6 +32,7 @@ class Template(object):
         self.kwds = kwds
 
     def _render(self, template_name, subdir):
+        import jinja2
         lgr.debug("Using template %s", template_name)
         env = jinja2.Environment(
             loader=jinja2.FileSystemLoader(


### PR DESCRIPTION
Otherwise it affects our startup time due to import of all the interfaces. Seems to shorten generic `--help` from >700ms to <500ms on my laptop. notably more responsive.  Also `reproman.api` import becomes only ~200 ms, from ~550ms.

See https://github.com/ReproNim/reproman/issues/397
for a more generic description of the issue and possible remedies.

I also have implemented a [basic ugly prototype for lazy loading of `yaml` module API](https://github.com/yarikoptic/ReproNim/compare/fda9c5184b668a178eba420974d54f8c8ca2fff8...opt-imports), since by itself it takes ~100 sec and for us would shave off ~40ms. BUT it is too ugly, and if we decide to go that way, we better generalize it for any module (e.g. `json` is one of the other ones).

TODOs:
- [x] I want to add a test to guarantee that we don't import additional heavy imports while importing `.api`