### PR TITLE
ENH: ssh: Include resource name in password prompt

### DIFF
--- a/reproman/resource/ssh.py
+++ b/reproman/resource/ssh.py
@@ -99,7 +99,8 @@ class SSH(Resource):
         try:
             self._connection.open()
         except AuthenticationException:
-            password = getpass.getpass()
+            password = getpass.getpass(
+                prompt="Password for {}: ".format(self.name))
             self._connection = Connection(
                 self.host,
                 user=self.user,


### PR DESCRIPTION
When the inventory contains a password-protected resource, calling
`niceman ls --refresh` will display a "Password: " prompt _before_
displaying the line for the resource.  Add the resource name to the
prompt so that users know what they are entering a password for.

For operations that work on a single resource (e.g., login), this
added information isn't useful, but it also doesn't hurt.

Re: #400