### PR TITLE
MNT: Consistently use yaml.safe_load()

### DIFF
--- a/reproman/distributions/conda.py
+++ b/reproman/distributions/conda.py
@@ -360,7 +360,7 @@ class CondaTracer(DistributionTracer):
                 '%s/bin/conda-env export -p %s'
                 % (root_prefix, conda_path)
             )
-            export = yaml.load(out)
+            export = yaml.safe_load(out)
         except Exception as exc:
             if "unrecognized arguments: -p" in exc_str(exc):
                 lgr.warning("Could not retrieve conda environment "

--- a/reproman/formats/reproman.py
+++ b/reproman/formats/reproman.py
@@ -55,11 +55,11 @@ class RepromanProvenance(Provenance):
         # either order should matter.  Now in some places then internally
         # sorting alphabetically for consistency
         if '\n' in source:
-            return yaml.load(source)
+            return yaml.safe_load(source)
 
         with open(source, 'r') as stream:
             try:
-                return yaml.load(stream)
+                return yaml.safe_load(stream)
             except yaml.YAMLError as exc:
                 lgr.error("Failed to load %s: %s", source, exc_str(exc))
                 raise  # TODO -- we might want a dedicated exception here

--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -37,7 +37,7 @@ def _load_specs(files):
     ret = []
     for f in files:
         with open(f) as fh:
-            ret.append(yaml.load(fh))
+            ret.append(yaml.safe_load(fh))
     return ret
 
 


### PR DESCRIPTION
Calling yaml.load() without explicitly defining the Loader is
deprecated as of PyYAML 5.1.  The more restrictive and safer variant,
which we already use in some spots, should be sufficient for our
purposes.

See <https://pyyaml.org/wiki/PyYAMLDocumentation#loading-yaml>.