### PR TITLE
MNT: orchestrators: Avoid DataLad's is_dirty()

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -672,7 +672,7 @@ def head_at(dataset, commit):
     A boolean indicating whether HEAD needed to be moved in order to make
     `commit` current.
     """
-    if dataset.repo.is_dirty():
+    if dataset.repo.dirty:
         raise OrchestratorError(
             "Refusing to work with dirty repository: {}"
             .format(dataset.path))

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -141,7 +141,7 @@ def dataset(base_dataset):
                                           ["git", "reset", "--hard", "root"])
     for f in base_dataset.repo.untracked_files:
         os.unlink(op.join(base_dataset.path, f))
-    assert not base_dataset.repo.is_dirty()
+    assert not base_dataset.repo.dirty
     return base_dataset
 
 
@@ -346,7 +346,7 @@ def test_head_at_empty_branch(dataset):
     dataset.repo.checkout("orph", options=["--orphan"])
     # FIXME: Use expose method once available.
     dataset.repo._git_custom_command([], ["git", "reset", "--hard"])
-    assert not dataset.repo.is_dirty()
+    assert not dataset.repo.dirty
     with pytest.raises(OrchestratorError) as exc:
         with orcs.head_at(dataset, "master"):
             pass


### PR DESCRIPTION
DataLad dropped {Git,Annex}Repo.is_dirty() in 077de16ff (RF: Retire
`Repo.is_dirty()`, 2019-04-13).  Instead of is_dirty(), use GitRepo's
dirty property, which still exists in the latest DataLad.  This should
give the same results because is_dirty() is called without arguments
in all these spots.