### PR TITLE
run: Parallel subjobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -81,6 +81,7 @@ install:
   - sudo sed -i -e 's/^Defaults.*secure_path.*$//' /etc/sudoers
   # for SVN tests (SVNRepoShim._ls_files_command())
   - sudo apt-get install sqlite3
+  - sudo apt-get install moreutils  # for concurrent jobs with local orchestrator
   - travis_retry sudo eatmydata apt-get install singularity-container
   - if [ ! -z "${INSTALL_DATALAD:-}" ]; then tools/ci/install_datalad; fi
   - if [ ! -z "${INSTALL_CONDOR:-}" ]; then tools/ci/install_condor; fi

--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -170,7 +170,7 @@ class Run(Interface):
         job_parameters=Parameter(
             metavar="PARAM",
             dest="job_parameters",
-            args=("-p", "--job-parameter"),
+            args=("--job-parameter", "--jp"),
             # TODO: Use nargs=+ like create's --backend-parameters?  I'd rather
             # use 'append' there.
             action="append",

--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -12,6 +12,7 @@
 from argparse import REMAINDER
 import collections
 import logging
+import itertools
 import textwrap
 import yaml
 
@@ -64,22 +65,86 @@ def _combine_job_specs(specs):
     return initial
 
 
-def _resolve_batch_parameters(spec_file):
+def _parse_batch_params(params):
+    """Transform batch parameter strings into lists of tuples.
+
+    Parameters
+    ----------
+    params : list of str
+        The string should have the form "key=val1,val2,val3".
+
+    Returns
+    -------
+    A generator that, for each key, yields a list of key-value tuple pairs.
+    """
+    seen_keys = set()
+    for param in params:
+        if "=" not in param:
+            raise ValueError(
+                "param value should be formatted as 'key=value,...'")
+        key, value_str = param.split("=", maxsplit=1)
+        if key in seen_keys:
+            raise ValueError("Key '{}' was given more than once".format(key))
+        seen_keys.add(key)
+        yield [(key, v) for v in value_str.split(",")]
+
+
+def _combine_batch_params(params):
+    """Transform batch parameter strings into records.
+
+    Parameters
+    ----------
+    params : list of str
+        The string should have the form "key=val1,val2,val3".
+
+    Returns
+    -------
+    A generator that yields a record, computing the product from the values.
+
+    >>> from pprint import pprint
+    >>> params = ["k0=val1,val2,val3", "k1=val4,val5"]
+    >>> pprint(list(_combine_batch_params(params)))
+    [{'k0': 'val1', 'k1': 'val4'},
+     {'k0': 'val1', 'k1': 'val5'},
+     {'k0': 'val2', 'k1': 'val4'},
+     {'k0': 'val2', 'k1': 'val5'},
+     {'k0': 'val3', 'k1': 'val4'},
+     {'k0': 'val3', 'k1': 'val5'}]
+    """
+    if not params:
+        return
+    # Note: If we want to support pairing the ith elements rather than taking
+    # the product, we could add a parameter that signals to use zip() rather
+    # than product(). If we do that, we'll also want to check that the values
+    # for each key are the same length, probably in _parse_batch_params().
+    for i in itertools.product(*_parse_batch_params(params)):
+        yield dict(i)
+
+
+def _resolve_batch_parameters(spec_file, params):
     """Determine batch parameters based on user input.
 
     Parameters
     ----------
     spec_file : str or None
         Name of YAML file the defines records of parameters.
+    params : list of str or None
+        The string should have the form "key=val1,val2,val3".
 
     Returns
     -------
-    List of records or None if `spec_file` is not specified.
+    List of records or None if neither `spec_file` or `params` is specified.
     """
+    if spec_file and params:
+        raise ValueError(
+            "Batch parameters cannot be provided with a batch spec")
+
     resolved = None
     if spec_file:
         with open(spec_file) as pf:
             resolved = yaml.safe_load(pf)
+    elif params:
+        resolved = list(_combine_batch_params(params))
     return resolved
 
 
@@ -103,6 +168,11 @@ JOB_PARAMETERS = collections.OrderedDict(
          commands. A command will be constructed for each record, with record
          values available in the command as well as the inputs and outputs as
          `{p[KEY]}`."""),
+        ("batch_parameters",
+         """Define batch parameters with 'KEY=val1,val2,...'. Different keys
+         can be specified by giving multiple values, in which case the product
+         of the values are taken. For example, 'subj=mei,satsuki' and 'day=1,2'
+         would expand to four records, pairing each subj with each day."""),
         ("inputs, outputs",
          """Input and output files (list) to the command."""),
         ("message",
@@ -157,7 +227,17 @@ class Run(Interface):
             args=("--batch-spec", "--bs"),
             dest="batch_spec",
             metavar="PATH",
-            doc=JOB_PARAMETERS["batch_spec"]),
+            doc=(JOB_PARAMETERS["batch_spec"] +
+                 " See [CMD: --batch-parameter CMD][PY: `batch_parameters` PY]"
+                 " for an alternative method for simple combinations.")),
+        batch_parameters=Parameter(
+            args=("--batch-parameter", "--bp"),
+            dest="batch_parameters",
+            action="append",
+            metavar="PATH",
+            doc=(JOB_PARAMETERS["batch_parameters"] +
+                 " See [CMD: --batch-spec CMD][PY: `batch_spec` PY]"
+                 " for specifying more complex records.")),
         job_specs=Parameter(
             args=("--job-spec", "--js"),
             dest="job_specs",
@@ -216,7 +296,7 @@ class Run(Interface):
     def __call__(command=None, message=None,
                  resref=None, resref_type="auto",
                  list_=None, submitter=None, orchestrator=None,
-                 batch_spec=None,
+                 batch_spec=None, batch_parameters=None,
                  job_specs=None, job_parameters=None,
                  inputs=None, outputs=None,
                  follow=False):
@@ -262,6 +342,7 @@ class Run(Interface):
                 "submitter": submitter,
                 "orchestrator": orchestrator,
                 "batch_spec": batch_spec,
+                "batch_parameters": batch_parameters,
                 "inputs": inputs,
                 "outputs": outputs,
             }.items()
@@ -275,7 +356,7 @@ class Run(Interface):
                                   [job_parameters, cli_spec])
 
         spec["batch_parameters"] = _resolve_batch_parameters(
-            spec.get("batch_spec"))
+            spec.get("batch_spec"), spec.get("batch_parameters"))
 
         # Treat "command" as a special case because it's a list and the
         # template expects a string.

--- a/reproman/interface/tests/test_run.py
+++ b/reproman/interface/tests/test_run.py
@@ -106,6 +106,20 @@ def test_combine_batch_params(params, expected):
     assert actual == expected
 
 
+def test_combine_batch_params_glob(tmpdir):
+    tmpdir = str(tmpdir)
+    create_tree(tmpdir, {"aaa": "a",
+                         "subdir": {"b": "b", "c": "c"}})
+    with chpwd(tmpdir):
+        res = sorted(_combine_batch_params(["foo=a*,subdir/*,other"]),
+                     key=lambda d: d["foo"])
+        assert list(res) == [
+            {"foo": "aaa"},
+            {"foo": "other"},
+            {"foo": "subdir/b"},
+            {"foo": "subdir/c"}]
+
+
 def test_combine_batch_params_repeat_key():
     with pytest.raises(ValueError):
         list(_combine_batch_params(["a=1", "a=2"]))

--- a/reproman/support/jobs/job_templates/runscript/base.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/base.template.sh
@@ -5,23 +5,26 @@
 set -eu
 
 jobid={{ jobid }}
+subjob=$1
+num_subjobs={{ num_subjobs }}
+
 metadir={{ shlex_quote(meta_directory) }}
 rootdir={{ shlex_quote(root_directory) }}
 workdir={{ shlex_quote(working_directory) }}
 
-echo "submitted" >"$metadir/status"
+echo "submitted" >"$metadir/status.$subjob"
 echo "[ReproMan] pre-command..."
 
 {% block pre_command %}
 cd "$workdir"
 {% endblock %}
 
-echo "running" >"$metadir/status"
+echo "running" >"$metadir/status.$subjob"
 echo "[ReproMan] executing command within $PWD..."
 {% block command %}
 /bin/sh -c {{ shlex_quote(command_str) }} && \
-    echo "succeeded" >"$metadir/status" || \
-    echo "failed: $?" >"$metadir/status"
+    echo "succeeded" >"$metadir/status.$subjob" || \
+    echo "failed: $?" >"$metadir/status.$subjob"
 {% endblock %}
 
 

--- a/reproman/support/jobs/job_templates/runscript/base.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/base.template.sh
@@ -12,6 +12,9 @@ metadir={{ shlex_quote(meta_directory) }}
 rootdir={{ shlex_quote(root_directory) }}
 workdir={{ shlex_quote(working_directory) }}
 
+_reproman_cmd_idx=$(($subjob + 1))
+export _reproman_cmd_idx
+
 echo "submitted" >"$metadir/status.$subjob"
 echo "[ReproMan] pre-command..."
 
@@ -19,19 +22,54 @@ echo "[ReproMan] pre-command..."
 cd "$workdir"
 {% endblock %}
 
+get_command () {
+    perl -n0e \
+         '$idx=$ENV{_reproman_cmd_idx}; print "$_" if $. == $idx;' \
+         "$metadir/command-array"
+}
+
+cmd=$(get_command)
+if test -z "$cmd"
+then
+    echo "[ReproMan] failed getting command at position $_reproman_cmd_idx" >&2
+    echo "pre-command failure" >"$metadir/status.$subjob"
+    exit 1
+fi
+
 echo "running" >"$metadir/status.$subjob"
-echo "[ReproMan] executing command within $PWD..."
+echo "[ReproMan] executing command $cmd"
+echo "[ReproMan] ... within $PWD"
 {% block command %}
-/bin/sh -c {{ shlex_quote(command_str) }} && \
+/bin/sh -c "$cmd" && \
     echo "succeeded" >"$metadir/status.$subjob" || \
     (echo "failed: $?" >"$metadir/status.$subjob";
      mkdir -p "$metadir/failed" && touch "$metadir/failed/$subjob")
 {% endblock %}
 
+if test $num_subjobs -eq $_reproman_cmd_idx
+then
+# Not all jobs should do the cleanup. Ideally none of them should and there
+# should be some post-job cleanup triggered through the batch system. But, at
+# least for now, below is a brittle solution were the last job waits until it
+# sees that all other jobs have exited and then runs the post-command stuff.
+nstatus () {
+    find "$metadir" -regex '.*/status\.[0-9]+' | wc -l
+}
+
+# Ugly, but this sleep makes it less likely for the post-command tar to fail
+# complaining about a log from another run is changing.
+sleep 1
+while test $(nstatus) -lt $num_subjobs
+do
+    echo "[ReproMan] Waiting for all jobs to complete before running post-command..."
+    sleep 3
+done
 
 echo "[ReproMan] post-command..."
+
 {% block post_command %}
 {% endblock %}
 
 mkdir -p "$rootdir/completed/"
 touch "$rootdir/completed/$jobid"
+fi

--- a/reproman/support/jobs/job_templates/runscript/base.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/base.template.sh
@@ -4,19 +4,24 @@
 
 set -eu
 
-echo "submitted" >"{{ meta_directory }}/status"
+jobid={{ jobid }}
+metadir={{ shlex_quote(meta_directory) }}
+rootdir={{ shlex_quote(root_directory) }}
+workdir={{ shlex_quote(working_directory) }}
+
+echo "submitted" >"$metadir/status"
 echo "[ReproMan] pre-command..."
 
 {% block pre_command %}
-cd "{{ working_directory }}"
+cd "$workdir"
 {% endblock %}
 
-echo "running" >"{{ meta_directory }}/status"
+echo "running" >"$metadir/status"
 echo "[ReproMan] executing command within $PWD..."
 {% block command %}
 /bin/sh -c {{ shlex_quote(command_str) }} && \
-    echo "succeeded" >"{{ meta_directory }}/status" || \
-    echo "failed: $?" >"{{ meta_directory }}/status"
+    echo "succeeded" >"$metadir/status" || \
+    echo "failed: $?" >"$metadir/status"
 {% endblock %}
 
 
@@ -24,5 +29,5 @@ echo "[ReproMan] post-command..."
 {% block post_command %}
 {% endblock %}
 
-mkdir -p "{{ root_directory }}/completed/"
-touch "{{ root_directory }}/completed/{{ jobid }}"
+mkdir -p "$rootdir/completed/"
+touch "$rootdir/completed/$jobid"

--- a/reproman/support/jobs/job_templates/runscript/base.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/base.template.sh
@@ -24,7 +24,8 @@ echo "[ReproMan] executing command within $PWD..."
 {% block command %}
 /bin/sh -c {{ shlex_quote(command_str) }} && \
     echo "succeeded" >"$metadir/status.$subjob" || \
-    echo "failed: $?" >"$metadir/status.$subjob"
+    (echo "failed: $?" >"$metadir/status.$subjob";
+     mkdir -p "$metadir/failed" && touch "$metadir/failed/$subjob")
 {% endblock %}
 
 

--- a/reproman/support/jobs/job_templates/runscript/includes/create-ref.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/create-ref.template.sh
@@ -1,1 +1,1 @@
-git update-ref refs/reproman/{{ jobid }} HEAD
+git update-ref refs/reproman/$jobid HEAD

--- a/reproman/support/jobs/job_templates/runscript/includes/datalad-add.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/datalad-add.template.sh
@@ -10,4 +10,4 @@ msg={{ shlex_quote(message) }}
 {% else %}
 msg="[ReproMan] save results for $jobid"
 {% endif %}
-datalad add -m"$msg" . .reproman >/dev/null 2>&1
+datalad add --recursive -m"$msg" . .reproman >/dev/null 2>&1

--- a/reproman/support/jobs/job_templates/runscript/includes/datalad-add.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/datalad-add.template.sh
@@ -8,6 +8,6 @@ echo "Using DataLad version $(datalad --version)"  # for debugging
 {% if message is defined %}
 msg={{ shlex_quote(message) }}
 {% else %}
-msg="[ReproMan] save results for {{ jobid }}"
+msg="[ReproMan] save results for $jobid"
 {% endif %}
 datalad add -m"$msg" . .reproman >/dev/null 2>&1

--- a/reproman/support/jobs/job_templates/runscript/includes/post-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/post-run.template.sh
@@ -27,7 +27,7 @@ fi
 mkdir -p "$rootdir/outputs"
 
 tar \
+  -C "$workdir" \
   --files-from "$metadir/togethome" \
   -cz \
-  -C "$workdir" \
   -f "$rootdir/outputs/$jobid.tar.gz"

--- a/reproman/support/jobs/job_templates/runscript/includes/post-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/post-run.template.sh
@@ -1,6 +1,6 @@
 {# Inspired by and modified from dataladh-htcondor. #}
 
-prep_stamp="{{ meta_directory }}/pre-finished"
+prep_stamp="$metadir/pre-finished"
 
 
 {#
@@ -8,20 +8,20 @@ prep_stamp="{{ meta_directory }}/pre-finished"
   the archive to be relative to this working directory.
 #}
 find ./.reproman \( -type f -o -type l \) | \
-    grep {{ jobid }}  >"{{ meta_directory }}/togethome"
+    grep $jobid  >"$metadir/togethome"
 
 if [ -f "$prep_stamp" ]; then
   find . \
      \( -type f -o -type l \) \
     -newer "$prep_stamp" \
     -not -wholename "./.reproman/*" \
-    >>"{{ meta_directory }}/togethome"
+    >>"$metadir/togethome"
 fi
 
-mkdir -p "{{ root_directory }}/outputs"
+mkdir -p "$rootdir/outputs"
 
 tar \
-  --files-from "{{ meta_directory }}/togethome" \
+  --files-from "$metadir/togethome" \
   -cz \
-  -C "{{ working_directory }}" \
-  -f "{{ root_directory }}/outputs/{{ jobid }}.tar.gz"
+  -C "$workdir" \
+  -f "$rootdir/outputs/$jobid.tar.gz"

--- a/reproman/support/jobs/job_templates/runscript/includes/post-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/post-run.template.sh
@@ -1,7 +1,12 @@
 {# Inspired by and modified from dataladh-htcondor. #}
 
-prep_stamp="$metadir/pre-finished"
+oldest_stamp () {
+    find "$metadir" \
+         -regex '.*/pre-finished\.[0-9]+' -printf '@%T@\n' | \
+        sort | head -n1
+}
 
+prep_stamp=$(oldest_stamp)
 
 {#
   Hmm, hard to use placeholders because those are absolute paths, but we want
@@ -10,10 +15,11 @@ prep_stamp="$metadir/pre-finished"
 find ./.reproman \( -type f -o -type l \) | \
     grep $jobid  >"$metadir/togethome"
 
-if [ -f "$prep_stamp" ]; then
+if test -n "$prep_stamp"
+then
   find . \
      \( -type f -o -type l \) \
-    -newer "$prep_stamp" \
+    -newermt "$prep_stamp" \
     -not -wholename "./.reproman/*" \
     >>"$metadir/togethome"
 fi

--- a/reproman/support/jobs/job_templates/runscript/includes/pre-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/pre-run.template.sh
@@ -1,2 +1,2 @@
-touch "$metadir/pre-finished"
+touch "$metadir/pre-finished.$subjob"
 sleep 1  # Increase odds that output can be detected by `find . -newer`.

--- a/reproman/support/jobs/job_templates/runscript/includes/pre-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/pre-run.template.sh
@@ -1,2 +1,2 @@
-touch "{{ meta_directory }}/pre-finished"
+touch "$metadir/pre-finished"
 sleep 1  # Increase odds that output can be detected by `find . -newer`.

--- a/reproman/support/jobs/job_templates/submission/condor.template
+++ b/reproman/support/jobs/job_templates/submission/condor.template
@@ -1,3 +1,7 @@
+{#
+  FIXME: How to handle spaces in file names?
+#}
+
 Universe     = vanilla
 Executable   = {{ meta_directory }}/runscript
 environment  = ""

--- a/reproman/support/jobs/job_templates/submission/condor.template
+++ b/reproman/support/jobs/job_templates/submission/condor.template
@@ -6,10 +6,9 @@ Universe     = vanilla
 Executable   = {{ meta_directory }}/runscript
 environment  = ""
 
-Output  = {{ meta_directory }}/stdout.0
-Error   = {{ meta_directory }}/stderr.0
-Log     = {{ meta_directory }}/log.0
-
+Output  = {{ meta_directory }}/stdout.$(Process)
+Error   = {{ meta_directory }}/stderr.$(Process)
+Log     = {{ meta_directory }}/log.$(Process)
 
 {#
   TODO: Need to check spec form compatibility between different batch
@@ -25,5 +24,5 @@ request_cpus = {{ num_processes }}
 {% endif %}
 
 getenv = True
-arguments = "0"
-queue
+arguments = "$(Process)"
+queue {{ num_subjobs }}

--- a/reproman/support/jobs/job_templates/submission/condor.template
+++ b/reproman/support/jobs/job_templates/submission/condor.template
@@ -6,9 +6,9 @@ Universe     = vanilla
 Executable   = {{ meta_directory }}/runscript
 environment  = ""
 
-Output  = {{ meta_directory }}/stdout
-Error   = {{ meta_directory }}/stderr
-Log     = {{ meta_directory }}/log
+Output  = {{ meta_directory }}/stdout.0
+Error   = {{ meta_directory }}/stderr.0
+Log     = {{ meta_directory }}/log.0
 
 
 {#
@@ -25,5 +25,5 @@ request_cpus = {{ num_processes }}
 {% endif %}
 
 getenv = True
-arguments = ""
+arguments = "0"
 queue

--- a/reproman/support/jobs/job_templates/submission/local.template
+++ b/reproman/support/jobs/job_templates/submission/local.template
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -eu
+
 metadir={{ shlex_quote(meta_directory) }}
 "$metadir/runscript" 1>"$metadir/stdout" 2>"$metadir/stderr" &
 RUNSCRIPT_PID=$!

--- a/reproman/support/jobs/job_templates/submission/local.template
+++ b/reproman/support/jobs/job_templates/submission/local.template
@@ -2,6 +2,6 @@
 set -eu
 
 metadir={{ shlex_quote(meta_directory) }}
-"$metadir/runscript" 1>"$metadir/stdout" 2>"$metadir/stderr" &
+"$metadir/runscript" 0 1>"$metadir/stdout.0" 2>"$metadir/stderr.0" &
 RUNSCRIPT_PID=$!
 printf "%d" $RUNSCRIPT_PID

--- a/reproman/support/jobs/job_templates/submission/local.template
+++ b/reproman/support/jobs/job_templates/submission/local.template
@@ -2,6 +2,31 @@
 set -eu
 
 metadir={{ shlex_quote(meta_directory) }}
-"$metadir/runscript" 0 1>"$metadir/stdout.0" 2>"$metadir/stderr.0" &
+num_subjobs={{ num_subjobs }}
+
+if test $num_subjobs -eq 1
+then
+    "$metadir/runscript" 0 1>"$metadir/stdout.0" 2>"$metadir/stderr.0" &
+else
+    if test -z $(which parallel)
+    then
+       echo "parallel (moreutils) is required to concurrent jobs locally" >&2
+       exit 1
+    fi
+
+    # Use relative path to meta directory because that doesn't need any special
+    # quoting, and the parallel call below wouldn't handle quoting properly.
+    metadir_rel={{ shlex_quote(meta_directory_rel) }}
+    workdir={{ shlex_quote(working_directory) }}
+
+    cd "$workdir"
+    parallel \
+        -i \
+        sh -c \
+        "$metadir_rel/runscript {} 1>$metadir_rel/stdout.{} 2>$metadir_rel/stderr.{}" \
+        -- $(seq 0 $(($num_subjobs - 1))) \
+        1>"$metadir_rel/stdout" 2>"$metadir_rel/stderr" &
+fi
+
 RUNSCRIPT_PID=$!
 printf "%d" $RUNSCRIPT_PID

--- a/reproman/support/jobs/job_templates/submission/local.template
+++ b/reproman/support/jobs/job_templates/submission/local.template
@@ -1,4 +1,5 @@
 #!/bin/sh
-{{ meta_directory }}/runscript 1>{{ meta_directory }}/stdout 2>{{ meta_directory }}/stderr &
+metadir={{ shlex_quote(meta_directory) }}
+"$metadir/runscript" 1>"$metadir/stdout" 2>"$metadir/stderr" &
 RUNSCRIPT_PID=$!
 printf "%d" $RUNSCRIPT_PID

--- a/reproman/support/jobs/job_templates/submission/pbs.template
+++ b/reproman/support/jobs/job_templates/submission/pbs.template
@@ -11,5 +11,10 @@
 {% if num_nodes is defined or num_processes is defined %}
 #PBS -l nodes={{ num_nodes|default(1, true) }}:ppn={{ num_processes|default(1, true) }}
 {% endif %}
+{% if num_subjobs == 1 %}
+#PBS -t 0
+{% else %}
+#PBS -t 0-{{ num_subjobs - 1}}
+{% endif %}
 
-{{ shlex_quote(meta_directory) }}/runscript 0
+{{ shlex_quote(meta_directory) }}/runscript ${PBS_ARRAYID}

--- a/reproman/support/jobs/job_templates/submission/pbs.template
+++ b/reproman/support/jobs/job_templates/submission/pbs.template
@@ -12,4 +12,4 @@
 #PBS -l nodes={{ num_nodes|default(1, true) }}:ppn={{ num_processes|default(1, true) }}
 {% endif %}
 
-{{ shlex_quote(meta_directory) }}/runscript
+{{ shlex_quote(meta_directory) }}/runscript 0

--- a/reproman/support/jobs/job_templates/submission/pbs.template
+++ b/reproman/support/jobs/job_templates/submission/pbs.template
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#PBS -o {{ meta_directory }}/stdout
-#PBS -e {{ meta_directory }}/stderr
+#PBS -o {{ shlex_quote(meta_directory) }}/stdout
+#PBS -e {{ shlex_quote(meta_directory) }}/stderr
 {% if walltime is defined %}
 #PBS -l walltime={{ walltime }}
 {% endif %}
@@ -12,4 +12,4 @@
 #PBS -l nodes={{ num_nodes|default(1, true) }}:ppn={{ num_processes|default(1, true) }}
 {% endif %}
 
-{{ meta_directory }}/runscript
+{{ shlex_quote(meta_directory) }}/runscript

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -597,12 +597,9 @@ class PrepareRemoteDataladMixin(object):
     def _execute_in_wdir(self, command, err_msg=None):
         """Helper to run command in remote working directory.
 
-        TODO: Adjust (or perhaps remove entirely) once
-        `SSHSession.execute_command` supports the `cwd` argument.
-
         Parameters
         ----------
-        command : str
+        command : list of str or str
         err_msg : optional
             Message to use if an OrchestratorError is raised.
 
@@ -614,9 +611,10 @@ class PrepareRemoteDataladMixin(object):
         ------
         OrchestratorError if command fails.
         """
-        prefix = "cd '{}' && ".format(self.working_directory)
         try:
-            out, _ = self.session.execute_command(prefix + command)
+            out, _ = self.session.execute_command(
+                command,
+                cwd=self.working_directory)
         except CommandError as exc:
             raise OrchestratorError(
                 str(exc) if err_msg is None else err_msg)

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -695,8 +695,8 @@ class PrepareRemoteDataladMixin(object):
         """
         self._checkout_target()
         # fixup 1: Check out target commit in subdatasets. This should later be
-        # replaced the planned Datalad functionality to get an entire dataset
-        # hierarchy to a recorded state.
+        # replaced by the planned Datalad functionality to get an entire
+        # dataset hierarchy to a recorded state.
         #
         # fixup 2: Autoenable remotes:
         # 'datalad publish' does not autoenable remotes, and 'datalad

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -218,11 +218,14 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
         """Submit the job with `submitter`.
         """
         lgr.info("Submitting %s", self.jobid)
-        templ = Template(**dict(self.job_spec,
-                                jobid=self.jobid,
-                                root_directory=self.root_directory,
-                                working_directory=self.working_directory,
-                                meta_directory=self.meta_directory))
+        templ = Template(
+            **dict(self.job_spec,
+                   jobid=self.jobid,
+                   root_directory=self.root_directory,
+                   working_directory=self.working_directory,
+                   meta_directory=self.meta_directory,
+                   meta_directory_rel=op.relpath(self.meta_directory,
+                                                 self.working_directory)))
         self.template = templ
         self._put_text(
             templ.render_runscript("{}.template.sh".format(

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -704,9 +704,11 @@ class PrepareRemoteDataladMixin(object):
         # autoenabling. Temporarily work around this issue, though this
         # should very likely be addressed in DataLad. And if this is here
         # to stay, we should avoid this call for non-annex datasets.
+        lgr.info("Adjusting state of remote dataset")
         self._execute_in_wdir(["git", "annex", "init"])
         for res in self._execute_datalad_json_command(
                 ["subdatasets", "--fulfilled=true", "--recursive"]):
+            lgr.debug("Adjusting state of %s", res["path"])
             cmds = [["git", "checkout", res["revision"]],
                     ["git", "annex", "init"]]
             for cmd in cmds:

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -22,6 +22,7 @@ This module has three main parts:
 import abc
 import collections
 from contextlib import contextmanager
+import json
 import logging
 import os
 import os.path as op
@@ -619,6 +620,10 @@ class PrepareRemoteDataladMixin(object):
             raise OrchestratorError(
                 str(exc) if err_msg is None else err_msg)
         return out
+
+    def _execute_datalad_json_command(self, subcommand):
+        out = self._execute_in_wdir(["datalad", "-f", "json"] + subcommand)
+        return map(json.loads, out.splitlines())
 
     @property
     def status(self):

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -267,6 +267,13 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
         return self.session.exists(
             op.join(self.root_directory, "completed", self.jobid))
 
+    @staticmethod
+    def _log_failed(jobid, metadir, status):
+        lgr.warning("Job status: %r. Check files in %s",
+                    status, metadir)
+        lgr.info("%s stderr: %s",
+                 jobid, op.join(metadir, "stderr"))
+
     def log_failed(self, func=None):
         """Display a log message about failed status.
 
@@ -283,10 +290,7 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
                 op.relpath(op.join(self.meta_directory),
                            self.working_directory),
                 "")
-            lgr.warning("Job status: %r. Check files in %s",
-                        status, local_metadir)
-            lgr.info("%s stderr: %s",
-                     self.jobid, op.join(local_metadir, "stderr"))
+            self._log_failed(self.jobid, local_metadir, status)
             if func:
                 func(local_metadir)
 

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -643,6 +643,7 @@ class PrepareRemoteDataladMixin(object):
             self._checkout_target()
 
             if inputs:
+                lgr.info("Making inputs available")
                 try:
                     # TODO: Whether we try this `get` should be configurable.
                     self._execute_in_wdir("datalad get {}".format(

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -407,8 +407,12 @@ def _datalad_check_container(ds, spec):
     """
     container = spec.get("container")
     if container is not None:
+        # TODO: This is repeating too much logic from containers-run. Consider
+        # reworking datalad-container to enable outside use.
         external_versions.check("datalad_container", min_version="0.4.0")
+        from datalad_container.containers_run import get_command_pwds
         from datalad_container.find_container import find_container
+
         try:
             cinfo = find_container(ds, container)
         except ValueError as exc:
@@ -417,9 +421,13 @@ def _datalad_check_container(ds, spec):
         cmdexec = cinfo["cmdexec"]
         image = op.relpath(cinfo["path"], ds.path)
 
+        pwd, _ = get_command_pwds(ds)
+        image_dspath = op.relpath(cinfo.get('parentds', ds.path), pwd)
+
         command_str = spec["command_str"]
         spec["commmand_str_nocontainer"] = command_str
-        spec["command_str"] = cmdexec.format(img=image, cmd=command_str)
+        spec["command_str"] = cmdexec.format(
+            img=image, cmd=command_str, img_dspath=image_dspath)
         spec["extra_inputs"] = [image]
 
 

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -250,15 +250,19 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
                 subm_id,
                 op.join(self.meta_directory, "idmap")))
 
-    @property
-    def status(self):
-        """Get information from job status file.
-        """
-        status_file = op.join(self.meta_directory, "status.0")
+    def get_status(self, subjob=0):
+        status_file = op.join(self.meta_directory,
+                              "status.{:d}".format(subjob))
         status = "unknown"
         if self.session.exists(status_file):
             status = self.session.read(status_file).strip()
         return status
+
+    @property
+    def status(self):
+        """Get information from job status file.
+        """
+        return self.get_status()
 
     @property
     def has_completed(self):

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -896,7 +896,11 @@ class FetchDataladRunMixin(object):
                         message=self.job_spec.get("message"),
                         cmd=self.job_spec["command_str_unexpanded"]):
                     # Oh, if only I were a datalad extension.
-                    pass
+                    if res["status"] in ["impossible", "error"]:
+                        raise OrchestratorError(
+                            "Making datalad-run commit failed: {}"
+                            .format(res["message"]))
+
                 ref = self.job_refname
                 if moved:
                     lgr.info("Results stored on %s. "

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -240,7 +240,9 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
             submission_file,
             executable=True)
 
-        subm_id = self.submitter.submit(submission_file)
+        subm_id = self.submitter.submit(
+            submission_file,
+            submit_command=self.job_spec.get("submit_command"))
         if subm_id is None:
             lgr.warning("No submission ID obtained for %s", self.jobid)
         else:

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -765,6 +765,21 @@ class PrepareRemoteDataladMixin(object):
 
             self._checkout_target()
 
+            # 'datalad publish' does not autoenable remotes, and 'datalad
+            # create-sibling' calls 'git annex init' too early to trigger
+            # autoenabling. Temporarily work around this issue, though this
+            # should very likely be addressed in DataLad. And if this is here
+            # to stay, we should avoid this call for non-annex datasets.
+            self._execute_in_wdir(["git", "annex", "init"])
+            for res in self._execute_datalad_json_command(
+                    ["subdatasets", "--fulfilled=true", "--recursive"]):
+                try:
+                    out, _ = self.session.execute_command(
+                        ["git", "annex", "init"],
+                        cwd=res["path"])
+                except CommandError as exc:
+                    raise OrchestratorError(str(exc))
+
             if inputs:
                 lgr.info("Making inputs available")
                 try:

--- a/reproman/support/jobs/submitters.py
+++ b/reproman/support/jobs/submitters.py
@@ -120,6 +120,15 @@ class PbsSubmitter(Submitter):
     @assert_submission_id
     @borrowdoc(Submitter)
     def status(self):
+        # FIXME: One problem is that Torque PBS may not represent the array
+        # consistently between versions (or perhaps configuration?). One system
+        # I try has [] in the name and allows qstat querying of the commands as
+        # a whole, while the other explodes them all out into individual jobs
+        # with no way AFAICS to query individual jobs. Going through DRMAA
+        # might help in many cases (and is probably something we should
+        # provide), but it's not a complete solution because a PBS system we
+        # want to support doesn't have DRMAA support.
+
         # FIXME: Is there a reliable, long-lived way to see a job after it's
         # completed?  (tracejob can fail with permission issues.)
         try:
@@ -162,9 +171,8 @@ class CondorSubmitter(Submitter):
         # Discard return value, which isn't submission ID for the current
         # condor_submit form.
         out = super(CondorSubmitter, self).submit(script, submit_command)
-        # We only handle single jobs at this point.
-        job_id, job_id0 = out.strip().split(" - ")
-        assert job_id == job_id0, "bug in job ID extraction logic"
+        # Output example (3 subjobs): 199.0 - 199.2
+        job_id = out.strip().split(" - ")[0].split(".")[0]
         self.submission_id = job_id
         return job_id
 
@@ -192,9 +200,6 @@ class CondorSubmitter(Submitter):
             return "unknown", None
 
         stat_json = json.loads(stat_out)
-        if len(stat_json) != 1:
-            lgr.warning("Expected a single status line, but got %s", stat_json)
-            return "unknown", None
 
         # http://pages.cs.wisc.edu/~adesmet/status.html
         condor_states = {0: "unexpanded",
@@ -205,14 +210,17 @@ class CondorSubmitter(Submitter):
                          5: "held",
                          6: "submission error"}
 
-        code = stat_json[0].get("JobStatus")
-        if code in [0, 1, 2, 5]:
+        codes = [sj.get("JobStatus") for sj in stat_json]
+        waiting_states = [0, 1, 2, 5]
+        if any(c in waiting_states for c in codes):
             our_status = "waiting"
-        elif code == 4:
+        elif all(c == 4 for c in codes):
             our_status = "completed"
         else:
             our_status = "unknown"
-        return our_status, condor_states.get(code)
+        # FIXME: their status should represent all subjobs, but right now we're
+        # just taking the first code.
+        return our_status, condor_states.get(codes[0])
 
     def _status_no_json(self):
         """Unclever status for older condor versions without 'condor_q -json'.
@@ -222,16 +230,29 @@ class CondorSubmitter(Submitter):
         stat_out, _ = self.session.execute_command(
             "condor_q {}".format(self.submission_id))
         last_line = stat_out.strip().splitlines()[-1]
-        # Try to match our json matching above. This leaves some out from both
-        # lists. I don't know what the exact map is.
-        for theirs, ours in [("completed", "completed"),
-                             ("removed", "unknown"),
-                             ("idle", "waiting"),
-                             ("running", "waiting"),
-                             ("held", "waiting")]:
-            if "1 {}".format(theirs) in last_line:
-                return ours, theirs
-        return "unknown", None
+
+        ours, theirs = "unknown", None
+        match_njobs = re.match(r"([1-9][0-9]*) jobs;", last_line.strip())
+        if match_njobs:
+            njobs = int(match_njobs.group(1))
+
+            # Try to match our json matching above. This leaves some out from
+            # both lists. I don't know what the exact map is.
+            to_ours = [(r"[1-9][0-9]* (idle|running|held)", "waiting"),
+                       (r"[1-9][0-9]* (removed)", "unknown"),
+                       # Only consider completed if we don't have a hit for
+                       # anything else and its number matches the total
+                       # reported number of jobs.
+                       (r"{} (completed)".format(njobs), "completed")]
+            for regexp, ours_ in to_ours:
+                match_stat = re.search(regexp, last_line)
+                if match_stat:
+                    theirs = match_stat.group(1)
+                    ours = ours_
+                    break
+        # FIXME: their status should represent all subjobs, but right now we're
+        # just taking the first hit from the list above.
+        return ours, theirs
 
 
 class LocalSubmitter(Submitter):

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -207,6 +207,13 @@ def test_orc_datalad_run_change_head(job_spec, dataset, shell):
             assert open("out").read() == "content\nmore\n"
 
 
+def test_orc_log_failed():
+    with swallow_logs(new_level=logging.INFO) as log:
+        orcs.Orchestrator._log_failed("jid", "metadir", "failed")
+        assert "Job status: 'failed'" in log.out
+        assert "jid stderr:" in log.out
+
+
 @pytest.mark.integration
 def test_orc_datalad_run_failed(job_spec, dataset, shell):
     job_spec["command_str"] = "iwillfail"

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -248,7 +248,7 @@ def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
             orc.follow()
 
         # The status for the first one is now out-of-tree ...
-        assert not op.exists(op.join(orc0.meta_directory, "status"))
+        assert not op.exists(op.join(orc0.meta_directory, "status.0"))
         # but we can still get it.
         assert orc0.status == "succeeded"
 
@@ -296,8 +296,8 @@ def test_orc_datalad_pair_run_ontop(job_spec, dataset, shell):
         orc1 = do(js1)
 
         # Ran on top, so both exist in working tree.
-        assert op.exists(op.join(orc0.meta_directory, "status"))
-        assert op.exists(op.join(orc1.meta_directory, "status"))
+        assert op.exists(op.join(orc0.meta_directory, "status.0"))
+        assert op.exists(op.join(orc1.meta_directory, "status.0"))
 
         ref0 = "refs/reproman/{}".format(orc0.jobid)
         ref1 = "refs/reproman/{}".format(orc1.jobid)

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -229,6 +229,21 @@ def test_orc_log_failed(failed):
 
 
 @pytest.mark.integration
+def test_orc_plain_failure(tmpdir, job_spec, shell):
+    job_spec["command_str"] = "iwillfail"
+    job_spec["inputs"] = []
+    local_dir = str(tmpdir)
+    with chpwd(local_dir):
+        orc = orcs.PlainOrchestrator(shell, submission_type="local",
+                                     job_spec=job_spec)
+        orc.prepare_remote()
+        orc.submit()
+        orc.follow()
+    for fname in "status", "stderr", "stdout":
+        assert op.exists(op.join(orc.meta_directory, fname + ".0"))
+
+
+@pytest.mark.integration
 def test_orc_datalad_run_failed(job_spec, dataset, shell):
     job_spec["command_str"] = "iwillfail"
     job_spec["inputs"] = []


### PR DESCRIPTION
Rework the orchestrators and submitters to support concurrent subjobs.

In terms of the `run` interface, this introduces a `--batch-spec` flag and a `--batch-parameter` flag for simple cases.  These control the number of subjobs.

An example invocation would be:

```
reproman run --follow -r ss --sub condor --orc datalad-pair-run --bp 'thing=thing-*' \
  --input '{p[thing]}' sh -c 'cat {p[thing]} {p[thing]} >doubled-{p[thing]}'
```

Assuming `[thing-a, thing-b, ...]` are globbed, that's equivalent to a --batch-spec with

```
thing:
- thing-a
- thing-b
[...]
```