### PR TITLE
 BF: orchestrator: Fix target commit checkout for shell resource

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -614,10 +614,10 @@ class PrepareRemoteDataladMixin(object):
             if not session.exists(self.working_directory):
                 dl.install(self.working_directory, source=self.ds.path)
 
-            self._checkout_target()
             self.session.execute_command(
                 "git push '{}' HEAD:{}-base"
                 .format(self.working_directory, self.job_refname))
+            self._checkout_target()
 
             if inputs:
                 installed_ds = dl.Dataset(self.working_directory)

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -212,7 +212,14 @@ def test_orc_datalad_run_failed(job_spec, dataset, shell):
 
 
 @pytest.mark.integration
-def test_orc_datalad_pair_run_multiple(job_spec, dataset, shell):
+def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
+    # Start two orchestrators from the same point:
+    #
+    #   orc 0, master
+    #   |
+    #   | orc 1
+    #   |/
+    #   o
     ds = dataset
     create_tree(ds.path, {"in": "content\n"})
     ds.add(".")

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -247,6 +247,7 @@ def test_orc_datalad_pair_run_multiple(job_spec, dataset, shell):
         # The other one is a side-branch.
         assert not ds.repo.is_ancestor(ref1, "HEAD")
         assert ds.repo.get_hexsha(ref0) == ds.repo.get_hexsha("master")
+        assert ds.repo.get_active_branch() == "master"
 
 
 @pytest.mark.integration

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -349,10 +349,10 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
     with chpwd(dataset.path):
         orc1 = orcs.DataladPairOrchestrator(
             shell, submission_type="local", job_spec=job_spec)
-    create_tree(orc1.working_directory, {"dirty": ""})
-    with pytest.raises(OrchestratorError) as exc:
-        orc1.prepare_remote()
-    assert "dirty" in str(exc)
+        create_tree(orc1.working_directory, {"dirty": ""})
+        with pytest.raises(OrchestratorError) as exc:
+            orc1.prepare_remote()
+        assert "dirty" in str(exc)
 
 
 def test_orc_datalad_abort_if_detached(job_spec, dataset, shell):


### PR DESCRIPTION
Adjust the local shell prepare_remote() procedure to check out the target *after* an existing remote dataset is updated.
