### PR TITLE
RF: external_versions: Drop cmd:datalad

### DIFF
--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -98,12 +98,6 @@ def _get_condor_version():
     return _runner.run(['condor_version'])[0].split()[1]
 
 
-def _get_datalad_version():
-    """Return version of available datalad"""
-    # Example output: datalad 0.11.3.dev17
-    return _runner.run(['datalad', '--version'])[0].split()[1]
-
-
 class ExternalVersions(object):
     """Helper to figure out/use versions of the externals (modules, cmdline tools, etc).
 
@@ -127,7 +121,6 @@ class ExternalVersions(object):
         'cmd:system-ssh': _get_system_ssh_version,
         'cmd:svn': _get_svn_version,
         'cmd:condor': _get_condor_version,
-        'cmd:datalad': _get_datalad_version,
         'cmd:apt-cache': _get_apt_cache_version
     }
     INTERESTING = (

--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -79,7 +79,7 @@ def no_condor():
 
 def no_datalad():
     return ("datalad not available",
-            not external_versions["cmd:datalad"])
+            not external_versions["datalad"])
 
 
 def no_docker_dependencies():


### PR DESCRIPTION
There's no reason to add a custom "cmd:" variant when we can inspect
at the version from the python module.