### PR TITLE
run: Adjust container job parameter to work with subdatsets

### DIFF
--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -84,6 +84,10 @@ JOB_PARAMETERS = collections.OrderedDict(
         ("message",
          """Message to use when saving the run. The details depend on the orchestator,
          but in general this message will be used in the commit message."""),
+        ("container",
+         """Container to use for execution. This should match the name of a container
+         registered with the datalad-container extension. This option is valid
+         only for DataLad run orchestrators."""),
         # TODO: Add more information for the rest of these.
         ("memory, num_processes",
          """Supported by Condor and PBS submitters."""),

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -464,7 +464,8 @@ class PrepareRemotePlainMixin(object):
             return
 
         for i in inputs:
-            session.put(i, op.join(self.working_directory, op.basename(i)))
+            session.put(i, op.join(self.working_directory,
+                                   op.relpath(i, self.local_directory)))
 
 
 def _format_ssh_url(user, host, port, path):

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -309,17 +309,20 @@ def _datalad_check_container(ds, spec):
     """
     container = spec.get("container")
     if container is not None:
+        try:
+            from datalad_container.find_container import find_container
+        except ImportError:
+            raise OrchestratorError(
+                "Specified container '{}' "
+                "but datalad-container extension is not installed"
+                .format(container))
+        try:
+            cinfo = find_container(ds, container)
+        except ValueError as exc:
+            raise OrchestratorError(exc)
 
-        def cfg_get(key):
-            full_key = "datalad.containers.{}.{}".format(container, key)
-            value = ds.config.get(full_key)
-            if value is None:
-                raise OrchestratorError(
-                    "No value configured for {}".format(full_key))
-            return value
-
-        cmdexec = cfg_get("cmdexec")
-        image = cfg_get("image")
+        cmdexec = cinfo["cmdexec"]
+        image = op.relpath(cinfo["path"], ds.path)
 
         command_str = spec["command_str"]
         spec["commmand_str_nocontainer"] = command_str

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -127,7 +127,8 @@ def base_dataset(tmpdir_factory):
     ds = dl.Dataset(path).create(force=True)
 
     create_tree(ds.path, {"foo": "foo",
-                          "bar": "bar"})
+                          "bar": "bar",
+                          "in": "content\n"})
     ds.add(".")
     ds.repo.tag("root")
     return ds
@@ -155,9 +156,6 @@ def dataset(base_dataset):
                           pytest.param("condor", marks=mark.skipif_no_condor)],
                          ids=["sub:local", "sub:condor"])
 def test_orc_datalad_run(job_spec, dataset, shell, orc_class, sub_type):
-    create_tree(dataset.path, {"in": "content\n"})
-    dataset.add(".")
-
     with chpwd(dataset.path):
         orc = orc_class(shell, submission_type=sub_type, job_spec=job_spec)
         orc.prepare_remote()
@@ -171,9 +169,6 @@ def test_orc_datalad_run(job_spec, dataset, shell, orc_class, sub_type):
 
 @pytest.mark.integration
 def test_orc_datalad_run_change_head(job_spec, dataset, shell):
-    create_tree(dataset.path, {"in": "content\n"})
-    dataset.add(".")
-
     with chpwd(dataset.path):
         orc = orcs.DataladLocalRunOrchestrator(
             shell, submission_type="local", job_spec=job_spec)
@@ -214,9 +209,6 @@ def test_orc_datalad_run_failed(job_spec, dataset, shell):
 @pytest.mark.integration
 def test_orc_datalad_pair_run_multiple(job_spec, dataset, shell):
     ds = dataset
-    create_tree(ds.path, {"in": "content\n"})
-    ds.add(".")
-
     js0 = job_spec
     js1 = dict(job_spec, command_str='bash -c "echo other >other"')
     with chpwd(ds.path):
@@ -251,9 +243,6 @@ def test_orc_datalad_pair_run_multiple(job_spec, dataset, shell):
 
 @pytest.mark.integration
 def test_orc_datalad_run_results_missing(job_spec, dataset, shell):
-    create_tree(dataset.path, {"in": "content\n"})
-    dataset.add(".")
-
     with chpwd(dataset.path):
         orc = orcs.DataladLocalRunOrchestrator(
             shell, submission_type="local", job_spec=job_spec)
@@ -268,9 +257,6 @@ def test_orc_datalad_run_results_missing(job_spec, dataset, shell):
 
 @pytest.mark.integration
 def test_orc_datalad_pair(job_spec, dataset, shell):
-    create_tree(dataset.path, {"in": "content\n"})
-    dataset.add(".")
-
     with chpwd(dataset.path):
         orc = orcs.DataladPairOrchestrator(
             shell, submission_type="local", job_spec=job_spec)
@@ -286,9 +272,6 @@ def test_orc_datalad_pair(job_spec, dataset, shell):
 
 @pytest.mark.integration
 def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
-    create_tree(dataset.path, {"in": "content\n"})
-    dataset.add(".")
-
     with chpwd(dataset.path):
         orc0 = orcs.DataladPairOrchestrator(
             shell, submission_type="local", job_spec=job_spec)

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -63,9 +63,9 @@ def test_orc_root_directory_error(shell, value):
 @pytest.fixture()
 def job_spec(tmpdir):
     return {"root_directory": op.join(str(tmpdir), "nm-run"),
-            "inputs": ["in"],
+            "inputs": [op.join("d", "in")],
             "outputs": ["out"],
-            "command_str": 'bash -c "cat in >out && echo more >>out"'}
+            "command_str": 'bash -c "cat d/in >out && echo more >>out"'}
 
 
 @pytest.fixture()
@@ -73,12 +73,13 @@ def check_orc_plain(tmpdir):
     local_dir = str(tmpdir)
 
     def fn(resource, jspec):
-        create_tree(local_dir, {"in": "content\n"})
+        create_tree(local_dir, {"d": {"in": "content\n"}})
         with chpwd(local_dir):
             orc = orcs.PlainOrchestrator(resource, submission_type="local",
                                          job_spec=jspec)
             orc.prepare_remote()
-            assert orc.session.exists(op.join(orc.working_directory, "in"))
+            assert orc.session.exists(
+                op.join(orc.working_directory, "d", "in"))
 
             orc.submit()
             orc.follow()
@@ -128,7 +129,7 @@ def base_dataset(tmpdir_factory):
 
     create_tree(ds.path, {"foo": "foo",
                           "bar": "bar",
-                          "in": "content\n"})
+                          "d": {"in": "content\n"}})
     ds.add(".")
     ds.repo.tag("root")
     return ds

--- a/tools/ci/install_datalad
+++ b/tools/ci/install_datalad
@@ -4,3 +4,4 @@ set -eu
 
 sudo apt-get install git-annex-standalone
 pip install git+https://github.com/datalad/datalad.git
+pip install datalad-container


### PR DESCRIPTION
We grab the datalad-containers information from the dataset's config,
but this approach only works for containers in the current dataset.
To support containers in subdatasets, we can instead retrieve the
container information with datalad-container's (relatively new)
find_container() helper.

---

- [x] Update DataLad Travis run to install `datalad-container` as well.