### PR TITLE
TST: Don't assume Ed is installed

### DIFF
--- a/reproman/distributions/tests/test_debian.py
+++ b/reproman/distributions/tests/test_debian.py
@@ -15,6 +15,7 @@ import logging
 from reproman.distributions.debian import DebTracer
 from reproman.distributions.debian import DEBPackage
 from reproman.distributions.debian import DebianDistribution
+from reproman.support.external_versions import external_versions
 
 import pytest
 
@@ -25,6 +26,8 @@ from reproman.tests.skip import mark
 
 
 @mark.skipif_no_apt_cache
+@pytest.mark.skipif("cmd:ed" not in external_versions,
+                    reason="Ed is not installed")
 def test_dpkg_manager_identify_packages():
     files = ["/bin/ed"]
     tracer = DebTracer()

--- a/reproman/distributions/tests/test_debian.py
+++ b/reproman/distributions/tests/test_debian.py
@@ -6,14 +6,11 @@
 #   copyright and license terms.
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
-import json
 import os
 from os.path import islink
 from os.path import join, isfile
 
 import logging
-
-import attr
 
 from reproman.distributions.debian import DebTracer
 from reproman.distributions.debian import DEBPackage

--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -49,6 +49,15 @@ def _get_annex_version():
     return _runner.run('git annex version --raw'.split())[0]
 
 
+def _get_ed_version():
+    """Return version of available Ed."""
+    # Example output:
+    #
+    # GNU Ed 1.10
+    # [...]
+    return _runner.run(["ed", "--version"])[0].split()[2]
+
+
 def _get_git_version():
     """Return version of available git"""
     return _runner.run('git version'.split())[0].split()[-1]
@@ -116,6 +125,7 @@ class ExternalVersions(object):
 
     CUSTOM = {
         'cmd:annex': _get_annex_version,
+        'cmd:ed': _get_ed_version,
         'cmd:git': _get_git_version,
         'cmd:singularity': _get_singularity_version,
         'cmd:system-ssh': _get_system_ssh_version,


### PR DESCRIPTION
test_dpkg_manager_identify_packages was failing for me locally because I didn't have Ed installed on my system.