### PR TITLE
TST: travis: Remove 'route' commands for NONETWORK run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,8 @@ install:
 script:
   # Verify that setup.py build doesn't puke
   - python setup.py build
-  - if [ ! -z "$REPROMAN_TESTS_NONETWORK" ]; then sudo route add -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # - $NOSE_WRAPPER `which nosetests` -s -v --with-doctest --doctest-tests --with-cov --cover-package reproman --logging-level=INFO
   - coverage run `which py.test` -s -rs --integration reproman
-  - if [ ! -z "$REPROMAN_TESTS_NONETWORK" ]; then sudo route del -net 0.0.0.0 netmask 0.0.0.0 dev lo; fi
   # Generate documentation and run doctests
   - PYTHONPATH=$PWD make -C docs html doctest
 


### PR DESCRIPTION
The REPROMAN_TESTS_NONETWORK run is hanging on the 'route add'
command (see gh-420).  The reason for this isn't clear, but let's
follow DataLad (where this setup is inherited from) and remove these
commands.  See DataLad's 64a4dd7aa (Remove messing with the route
table -- not sure how/if it works currently, 2016-09-15).