### PR TITLE
BF: exception cannot be logged, preceding debug() already logs its exc_str

### DIFF
--- a/reproman/distributions/singularity.py
+++ b/reproman/distributions/singularity.py
@@ -150,7 +150,6 @@ class SingularityTracer(DistributionTracer):
             except Exception as exc:
                 lgr.debug("Probably %s is not a Singularity image: %s",
                     file_path, exc_str(exc))
-                lgr.debug(exc)
                 remaining_files.add(file_path)
 
         if not images:


### PR DESCRIPTION

    $> REPROMAN_LOGLEVEL=1 python -c 'from reproman import lgr; lgr.debug(ValueError("kaboom"))'
    2019-05-23 13:49:11,631 [Level 5] Instantiating config
    2019-05-23 13:49:11,638 [DEBUG  ] Reading files: ['/etc/reproman/reproman.cfg', '/etc/xdg/reproman/reproman.cfg', '/home/yoh/.config/reproman/reproman.cfg', '.reproman/reproman.cfg']
    2019-05-23 13:49:11,642 [Level 5] Done importing main __init__
    --- Logging error ---
    Traceback (most recent call last):
      File "/usr/lib/python3.7/logging/__init__.py", line 1034, in emit
        msg = self.format(record)
      File "/usr/lib/python3.7/logging/__init__.py", line 880, in format
        return fmt.format(record)
      File "/home/yoh/proj/repronim/reproman/reproman/log.py", line 141, in format
        if record.msg.startswith('| '):
    AttributeError: 'ValueError' object has no attribute 'startswith'
    Call stack:
      File "<string>", line 1, in <module>
    Message: ValueError('kaboom')
    Arguments: ()
    2019-05-23 13:49:11,644 [Level 5] Exiting