### PR TITLE
RF: use /bin/bash instead of /bin/ed or /sbin/iptables, define centrally

### DIFF
--- a/reproman/distributions/tests/test_debian.py
+++ b/reproman/distributions/tests/test_debian.py
@@ -25,19 +25,23 @@ from unittest import mock
 
 from reproman.utils import swallow_logs
 from reproman.tests.skip import mark
+from reproman.tests.utils import (
+    COMMON_SYSTEM_PATH,
+    COMMON_SYSTEM_PACKAGE,
+)
 
 
 @mark.skipif_no_apt_cache
 def test_dpkg_manager_identify_packages():
-    files = ["/bin/ed"]
+    files = [COMMON_SYSTEM_PATH]
     tracer = DebTracer()
     (packages, unknown_files) = \
         tracer.identify_packages_from_files(files)
-    # Make sure that iptables was identified
-    assert (not unknown_files), "/bin/ed should be identified"
+    # Make sure that our common path was identified
+    assert (not unknown_files), "%s should be identified" % COMMON_SYSTEM_PATH
     assert len(packages) == 1
     pkg = packages[0]
-    assert pkg.name == 'ed'
+    assert pkg.name == COMMON_SYSTEM_PACKAGE
     # Make sure apt_sources are identified, but then we should ask the entire
     # distribution
     distributions = list(tracer.identify_distributions(files))

--- a/reproman/distributions/tests/test_vcs.py
+++ b/reproman/distributions/tests/test_vcs.py
@@ -21,6 +21,7 @@ from reproman.support.exceptions import CommandError
 from reproman.utils import chpwd
 from reproman.utils import swallow_logs
 from reproman.tests.utils import assert_is_subset_recur
+from reproman.tests.utils import COMMON_SYSTEM_PATH
 from reproman.tests.utils import create_tree
 from reproman.tests.utils import with_tree
 from reproman.tests.fixtures import git_repo_fixture, svn_repo_fixture
@@ -100,11 +101,11 @@ def test_git_repo(git_repo):
     tracer = VCSTracer()
 
     with chpwd(git_repo):
-        dists = list(tracer.identify_distributions(paths + ["/sbin/iptables"]))
+        dists = list(tracer.identify_distributions(paths + [COMMON_SYSTEM_PATH]))
         assert_distributions(
             dists,
             expected_length=1,
-            expected_unknown={"/sbin/iptables"},
+            expected_unknown={COMMON_SYSTEM_PATH},
             expected_subset={
                 "name": "git",
                 "packages": [{"files": [op.relpath(p) for p in paths],

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -21,6 +21,7 @@ from reproman.utils import on_linux
 from reproman.utils import swallow_logs
 from reproman.tests.utils import create_pymodule
 from reproman.tests.utils import assert_is_subset_recur
+from reproman.tests.utils import COMMON_SYSTEM_PATH
 from reproman.tests.skip import skipif
 from reproman.distributions.venv import VenvDistribution
 from reproman.distributions.venv import VenvEnvironment
@@ -77,7 +78,7 @@ def test_venv_identify_distributions(venv_test_dir):
             # or in a directory that is a link to the outside world.
             os.path.join("venv1", libpaths["machinery.py"])
         ]
-        path_args.append("/sbin/iptables")
+        path_args.append(COMMON_SYSTEM_PATH)
 
         tracer = VenvTracer()
 
@@ -89,7 +90,7 @@ def test_venv_identify_distributions(venv_test_dir):
         # another path within venv0, but they do include the link to the system
         # abc.py.
         assert unknown_files == {
-            "/sbin/iptables",
+            COMMON_SYSTEM_PATH,
             op.realpath(os.path.join("venv1", libpaths["abc.py"])),
             op.realpath(os.path.join("venv1", libpaths["machinery.py"])),
             # The editable package was added by VenvTracer as an unknown file.

--- a/reproman/interface/tests/test_retrace.py
+++ b/reproman/interface/tests/test_retrace.py
@@ -12,7 +12,10 @@ from reproman.formats import Provenance
 import logging
 
 from reproman.utils import swallow_logs, swallow_outputs, make_tempfile
-from reproman.tests.utils import assert_in
+from reproman.tests.utils import (
+    assert_in,
+    COMMON_SYSTEM_PATH,
+)
 from reproman.tests.skip import mark
 
 from ..retrace import identify_distributions
@@ -46,7 +49,7 @@ def test_retrace_to_output_file(reprozip_spec2):
 def test_retrace_normalize_paths():
     # Retrace should normalize paths before passing them to tracers.
     with swallow_outputs() as cm:
-        main(["retrace", "/sbin/../sbin/iptables"])
+        main(["retrace", "/bin/.." + COMMON_SYSTEM_PATH])
         assert "name: debian" in cm.out
 
 

--- a/reproman/tests/utils.py
+++ b/reproman/tests/utils.py
@@ -36,6 +36,11 @@ from ..dochelpers import borrowkwargs
 # temp paths used by clones
 _TEMP_PATHS_CLONES = set()
 
+# The path to be used while retracing and expecting it to be
+# provided by some system package
+COMMON_SYSTEM_PATH = '/bin/bash'
+# Package it should belong to (to avoid guessing or assuming matching the name)
+COMMON_SYSTEM_PACKAGE = 'bash'
 
 # pytest variants for nose.tools commands.  These exist to avoid unnecessary
 # churn in tests that already use these names.  New code should use plain


### PR DESCRIPTION
/bin/ed was found to be absent on real-life systems (apparently not that many
tools depend on good old ed).

iptables is being deprecated by nftables, and exists as a symlink/alternative
on Debian systems. Unfortunately we do not even track alternatives ATM (ref #102)

Closes #423