### PR TITLE
RF: revert to default cmp=True for attr.s. Rely on frozen to get hash generated

### DIFF
--- a/reproman/distributions/debian.py
+++ b/reproman/distributions/debian.py
@@ -52,7 +52,7 @@ from ..support.exceptions import CommandError
 # TODO: flyweight/singleton ?
 # To make them hashable we need to freeze them... not sure if we are ready:
 #@attr.s(cmp=True, hash=True, frozen=True)
-@attr.s(cmp=True)
+@attr.s
 class APTSource(SpecObject):
     """APT origin information
     """
@@ -69,7 +69,7 @@ class APTSource(SpecObject):
 _register_with_representer(APTSource)
 
 
-@attr.s(slots=True, frozen=True, cmp=False, hash=True)
+@attr.s(slots=True, frozen=True, hash=True)
 class DEBPackage(Package):
     """Debian package information"""
     name = attrib(default=attr.NOTHING)

--- a/reproman/distributions/debian.py
+++ b/reproman/distributions/debian.py
@@ -51,7 +51,7 @@ from ..support.exceptions import CommandError
 
 # TODO: flyweight/singleton ?
 # To make them hashable we need to freeze them... not sure if we are ready:
-#@attr.s(cmp=True, hash=True, frozen=True)
+#@attr.s(cmp=True, frozen=True)
 @attr.s
 class APTSource(SpecObject):
     """APT origin information
@@ -69,7 +69,7 @@ class APTSource(SpecObject):
 _register_with_representer(APTSource)
 
 
-@attr.s(slots=True, frozen=True, hash=True)
+@attr.s(slots=True, frozen=True)
 class DEBPackage(Package):
     """Debian package information"""
     name = attrib(default=attr.NOTHING)

--- a/reproman/distributions/docker.py
+++ b/reproman/distributions/docker.py
@@ -23,7 +23,7 @@ from ..support.exceptions import CommandError
 from ..utils import attrib
 
 
-@attr.s(slots=True, frozen=True, hash=True)
+@attr.s(slots=True, frozen=True)
 class DockerImage(Package):
     """Docker image information"""
     id = attrib(default=attr.NOTHING)

--- a/reproman/distributions/docker.py
+++ b/reproman/distributions/docker.py
@@ -23,7 +23,7 @@ from ..support.exceptions import CommandError
 from ..utils import attrib
 
 
-@attr.s(slots=True, frozen=True, cmp=False, hash=True)
+@attr.s(slots=True, frozen=True, hash=True)
 class DockerImage(Package):
     """Docker image information"""
     id = attrib(default=attr.NOTHING)

--- a/reproman/distributions/redhat.py
+++ b/reproman/distributions/redhat.py
@@ -45,7 +45,7 @@ class RPMSource(SpecObject):
 _register_with_representer(RPMSource)
 
 
-@attr.s(slots=True, frozen=True, cmp=False, hash=True)
+@attr.s(slots=True, frozen=True, hash=True)
 class RPMPackage(Package):
     """Redhat package information"""
     name = attrib(default=attr.NOTHING)

--- a/reproman/distributions/redhat.py
+++ b/reproman/distributions/redhat.py
@@ -45,7 +45,7 @@ class RPMSource(SpecObject):
 _register_with_representer(RPMSource)
 
 
-@attr.s(slots=True, frozen=True, hash=True)
+@attr.s(slots=True, frozen=True)
 class RPMPackage(Package):
     """Redhat package information"""
     name = attrib(default=attr.NOTHING)

--- a/reproman/distributions/singularity.py
+++ b/reproman/distributions/singularity.py
@@ -26,7 +26,7 @@ from ..dochelpers import borrowdoc, exc_str
 from ..utils import attrib, md5sum, chpwd
 
 
-@attr.s(slots=True, frozen=True, cmp=False, hash=True)
+@attr.s(slots=True, frozen=True, hash=True)
 class SingularityImage(Package):
     """Singularity image information"""
     md5 = attrib(default=attr.NOTHING)

--- a/reproman/distributions/singularity.py
+++ b/reproman/distributions/singularity.py
@@ -26,7 +26,7 @@ from ..dochelpers import borrowdoc, exc_str
 from ..utils import attrib, md5sum, chpwd
 
 
-@attr.s(slots=True, frozen=True, hash=True)
+@attr.s(slots=True, frozen=True)
 class SingularityImage(Package):
     """Singularity image information"""
     md5 = attrib(default=attr.NOTHING)


### PR DESCRIPTION
It is not clear if we really had to disable `cmp` which hinders simple comparison of our objects.  
Having some tests still failing locally (yet to troubleshoot), submitting to CI