### PR TITLE
BF: skip: Don't swallow AttributeError's from condition functions

### DIFF
--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -148,6 +148,15 @@ CONDITION_FNS = [
 # Entry points: skipif and mark
 
 
+class NamespaceAttributeError(AttributeError):
+    """Namespace-specific AttributeError.
+
+    Raised by Namespace when it cannot find the specified condition function.
+    Using a derived class allows us to distinguish an unknown condition
+    function from a condition function that raises an AttributeError.
+    """
+
+
 class Namespace(object, metaclass=abc.ABCMeta):
     """Provide namespace skip conditions in CONDITION_FNS.
     """
@@ -163,7 +172,7 @@ class Namespace(object, metaclass=abc.ABCMeta):
         try:
             condfn = self.fns[item]
         except KeyError:
-            raise AttributeError(item) from None
+            raise NamespaceAttributeError(item) from None
         return self.attr_value(condfn)
 
 
@@ -200,7 +209,7 @@ class Mark(Namespace):
         if item.startswith("skipif_"):
             try:
                 return super(Mark, self).__getattr__(item[len("skipif_"):])
-            except AttributeError:
+            except NamespaceAttributeError:
                 # Fall back to the original item name so that the attribute
                 # error message doesn't confusingly drop "skipif_".
                 pass

--- a/reproman/tests/test_skip.py
+++ b/reproman/tests/test_skip.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from reproman.tests.skip import Mark
 from reproman.tests.skip import mark
 from reproman.tests.skip import skipif
 
@@ -47,3 +48,18 @@ def test_skipif_unknown_attribute():
 def test_mark_skipif_unknown_attribute():
     with pytest.raises(AttributeError):
         mark.skipif_youdontknowme
+
+
+def test_other_attribute_error():
+    # If a condition function raises an AttributeError, Mark doesn't mistake it
+    # for an unknown condition function.
+
+    def no_confusion():
+        raise AttributeError("don't get confused")
+
+    with patch("reproman.tests.skip.Namespace.fns",
+               {"no_confusion": no_confusion}):
+        with pytest.raises(AttributeError) as exc:
+            m = Mark()
+            m.skipif_no_confusion
+        assert "don't get confused" in str(exc)


### PR DESCRIPTION
```
Within Mark.__getattr__(), an AttributeError can be raised either
because the specified condition function (i.e. mark.skipif_FN) does
not exist or because the condition function itself raises an
AttributeError.  We didn't consider the latter, leading to confusing
error messages about skipif_FN not existing when FN raises an
AttributeError.

Distinguish the two cases above by adjusting Namespace to raise a
Namespace-specific subclass of AttributeError when it can't find a
condition function.
```

Fixes #429.