### PR TITLE
ENH: VenvEnvironment: Add system_site_packages attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,11 @@ matrix:
     env:
     - REPROMAN_TESTS_SSH=1
     - REPROMAN_TESTS_DEPS=core
+    - REPROMAN_TESTS_ASSUME_SSP=1
+    # Set this to test tracing virtual environments created with
+    # --system-site-packages.
+    virtualenv:
+      system_site_packages: true
   - python: 3.5
     # By default no logs will be output. This one is to test with log output at INFO level
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -347,6 +347,13 @@ Refer reproman/config.py for information on how to add these environment variabl
 - *REPROMAN_TESTS_SSH*: 
   Skips SSH tests if this flag is **not** set
 - *REPROMAN_LOGTRACEBACK*: 
+- *REPROMAN_TESTS_ASSUME_SSP*:
+  Set this to indicate that tests can assume that Python system site
+  packages are exposed in the testing environment (i.e., an
+  environment created with `virtualenv --system-site-packages ...`
+  would include system packages) and that there is at least one system
+  package present.  This is currently only relevant for the virtualenv
+  distribution tests.
   Runs TraceBack function with collide set to True, if this flag is set to 'collide'.
   This replaces any common prefix between current traceback log and previous invocation with "..."
 - *REPROMAN_TESTS_NOTEARDOWN*: 

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -35,7 +35,12 @@ PY_VERSION = "python{v.major}.{v.minor}".format(v=sys.version_info)
 def venv_test_dir():
     skipif.no_network()
     dirs = AppDirs('reproman')
-    test_dir = os.path.join(dirs.user_cache_dir, 'venv_test')
+
+    ssp = os.getenv("REPROMAN_TESTS_ASSUME_SSP")
+    # Encode the SSP value in the directory name so that the caller doesn't
+    # have to worry about deleting the cached venvs before setting the flag..
+    test_dir = os.path.join(dirs.user_cache_dir,
+                            'venv_test{}'.format("_ssp" if ssp else ""))
     if os.path.exists(test_dir):
         return test_dir
 
@@ -53,6 +58,14 @@ def venv_test_dir():
     runner.run([pip1, "install", "attrs"])
     # Make sure we're compatible with older pips.
     runner.run([pip1, "install", "pip==9.0.3"])
+
+    if ssp:
+        # The testing environment supports --system_site_packages.
+        pip2 = op.join("venv-nonlocal", "bin", "pip")
+        runner.run(["virtualenv", "--python", PY_VERSION,
+                    "--system-site-packages", "venv-nonlocal"])
+        runner.run([pip2, "install", "attrs"])
+
     return test_dir
 
 
@@ -103,11 +116,35 @@ def test_venv_identify_distributions(venv_test_dir):
                                   "name": "PyYAML",
                                   "editable": False},
                                  {"files": [], "name": "nmtest",
-                                  "editable": True}]},
+                                  "editable": True}],
+                    "system_site_packages": False},
                    {"packages": [{"files": [libpaths["filters.py"]],
                                   "name": "attrs",
-                                  "editable": False}]}]}
+                                  "editable": False}],
+                    "system_site_packages": False}]}
         assert_is_subset_recur(expect, attr.asdict(distributions), [dict, list])
+
+
+@pytest.mark.skipif(not os.getenv("REPROMAN_TESTS_ASSUME_SSP"),
+                    reason=("Will not assume system site packages "
+                            "unless REPROMAN_TESTS_ASSUME_SSP is set"))
+@pytest.mark.integration
+def test_venv_system_site_packages(venv_test_dir):
+    with chpwd(venv_test_dir):
+        tracer = VenvTracer()
+        libpath = op.join("lib", PY_VERSION,
+                          "site-packages", "attr", "filters.py")
+        dists = list(
+            tracer.identify_distributions([op.join("venv-nonlocal", libpath)]))
+        assert len(dists) == 1
+        vdist = dists[0][0]
+        # We won't do detailed inspection of this because its structure depends
+        # on a system we don't control, but we still want to make sure that
+        # VenvEnvironment's system_site_packages attribute is set correctly.
+        expect = {"environments": [{"packages": [{"files": [libpath],
+                                                  "name": "attrs"}],
+                                    "system_site_packages": True}]}
+        assert_is_subset_recur(expect, attr.asdict(vdist), [dict, list])
 
 
 @pytest.mark.integration
@@ -142,9 +179,11 @@ def test_venv_install(venv_test_dir, tmpdir):
 
     expect = {"environments":
               [{"packages": [{"name": "PyYAML",
-                              "editable": False}]},
+                              "editable": False}],
+                "system_site_packages": False},
                {"packages": [{"name": "attrs",
-                              "editable": False}]}]}
+                              "editable": False}],
+                "system_site_packages": False}]}
     assert_is_subset_recur(expect, attr.asdict(dist_installed), [dict, list])
 
     # We don't yet handle editable packages.

--- a/reproman/distributions/venv.py
+++ b/reproman/distributions/venv.py
@@ -44,6 +44,9 @@ class VenvPackage(Package):
 class VenvEnvironment(SpecObject):
     path = attrib()
     python_version = attrib()
+    system_site_packages = attrib(
+        default=False,
+        doc="Are any non-local packages present in the environment?")
     packages = TypedList(VenvPackage)
 
 
@@ -181,9 +184,11 @@ class VenvTracer(DistributionTracer):
             found_package_count += len(packages)
 
             venvs.append(
-                VenvEnvironment(path=venv_path,
-                                python_version=self._python_version(venv_path),
-                                packages=packages))
+                VenvEnvironment(
+                    path=venv_path,
+                    python_version=self._python_version(venv_path),
+                    system_site_packages=any(not p.local for p in packages),
+                    packages=packages))
 
         if venvs:
             yield (VenvDistribution(name="venv",


### PR DESCRIPTION
VenvPackage has a local attribute that is set to true if the package
is a local package (as classified by 'pip list --local'), so if
someone wanted to determine whether the environment was created with
--system-site-packages, they could inspect VenvEnvironment for any
packages without local=True.  But this is tedious to do by visual
inspection.  Plus we plan to add support for pruning packages without
files, in which case inspecting the environment object after the fact
would no longer be a reliable way of knowing that
--system-site-packages was used.

Add a VenvEnvironment attribute that explicitly marks whether the
environment has non-local packages.

Closes #428.