### PR TITLE
Singularity fixes and testing improvements

### DIFF
--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -7,8 +7,7 @@
 #
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
-import os
-import tempfile
+import os.path as op
 
 from ...cmd import Runner
 from ...distributions.singularity import SingularityTracer
@@ -17,13 +16,13 @@ from ...tests.skip import mark
 
 @mark.skipif_no_network
 @mark.skipif_no_singularity
-def test_singularity_trace():
-
+def test_singularity_trace(tmpdir):
+    tmpdir = str(tmpdir)
     # Download and set up singularity image file
     runner = Runner()
     runner.run(['singularity', 'pull',
         'shub://vsoch/hello-world@42e1f04ed80217895f8c960bdde6bef4d34fab59'])
-    image_file = tempfile.mktemp()
+    image_file = op.join(tmpdir, "img")
     os.rename('vsoch-hello-world-master-latest.simg', image_file)
 
     # Test tracer class
@@ -42,9 +41,6 @@ def test_singularity_trace():
     assert dist.images[0].singularity_version == '2.4-feature-squashbuild-secbuild.g780c84d'
     assert dist.images[0].base_image == 'ubuntu:14.04'
     assert 'non-existent-image' in remaining_files
-
-    # Clean up test files
-    os.remove(image_file)
 
     # Run tracer against a Singularity Hub url
     files = ['shub:/GodloveD/lolcow@a59d8de3121579fe9c95ab8af0297c2e3aefd827']

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -11,8 +11,6 @@ import os
 import tempfile
 
 from ...cmd import Runner
-# from ...distributions.singularity import SingularityDistribution
-# from ...distributions.singularity import SingularityImage
 from ...distributions.singularity import SingularityTracer
 from ...tests.skip import mark
 

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -29,7 +29,7 @@ def test_singularity_trace():
     # Test tracer class
     tracer = SingularityTracer()
 
-    files = [image_file, 'non-existant-image']
+    files = [image_file, 'non-existent-image']
     dist, remaining_files = next(tracer.identify_distributions(files))
 
     assert dist.images[0].md5 == 'ed9755a0871f04db3e14971bec56a33f'
@@ -41,7 +41,7 @@ def test_singularity_trace():
     assert dist.images[0].build_size == '333MB'
     assert dist.images[0].singularity_version == '2.4-feature-squashbuild-secbuild.g780c84d'
     assert dist.images[0].base_image == 'ubuntu:14.04'
-    assert 'non-existant-image' in remaining_files
+    assert 'non-existent-image' in remaining_files
 
     # Clean up test files
     os.remove(image_file)

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -35,14 +35,14 @@ def test_singularity_trace(tmpdir):
     for path in [op.join(tmpdir, "img"), "shub:/" + location]:
         files = [path, 'non-existent-image']
         dist, remaining_files = next(tracer.identify_distributions(files))
-
-        assert dist.images[0].md5 == 'ed9755a0871f04db3e14971bec56a33f'
-        assert dist.images[0].bootstrap == 'docker'
-        assert dist.images[0].maintainer == 'vanessasaur'
-        assert dist.images[0].deffile == 'Singularity'
-        assert dist.images[0].schema_version == '1.0'
-        assert dist.images[0].build_date == '2017-10-15T12:52:56+00:00'
-        assert dist.images[0].build_size == '333MB'
-        assert dist.images[0].singularity_version == '2.4-feature-squashbuild-secbuild.g780c84d'
-        assert dist.images[0].base_image == 'ubuntu:14.04'
+        img_info = dist.images[0]
+        assert img_info.md5 == 'ed9755a0871f04db3e14971bec56a33f'
+        assert img_info.bootstrap == 'docker'
+        assert img_info.maintainer == 'vanessasaur'
+        assert img_info.deffile == 'Singularity'
+        assert img_info.schema_version == '1.0'
+        assert img_info.build_date == '2017-10-15T12:52:56+00:00'
+        assert img_info.build_size == '333MB'
+        assert img_info.singularity_version == '2.4-feature-squashbuild-secbuild.g780c84d'
+        assert img_info.base_image == 'ubuntu:14.04'
         assert 'non-existent-image' in remaining_files

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -26,36 +26,23 @@ def test_singularity_trace(tmpdir):
     tmpdir = str(tmpdir)
     # Download and set up singularity image file
     runner = Runner(cwd=tmpdir)
-    runner.run(['singularity', 'pull', '--name', 'img',
-        'shub://vsoch/hello-world@42e1f04ed80217895f8c960bdde6bef4d34fab59'])
-    image_file = op.join(tmpdir, "img")
+    location = 'vsoch/hello-world@42e1f04ed80217895f8c960bdde6bef4d34fab59'
+    runner.run(['singularity', 'pull', '--name', 'img', 'shub://' + location])
 
     # Test tracer class
     tracer = SingularityTracer()
 
-    files = [image_file, 'non-existent-image']
-    dist, remaining_files = next(tracer.identify_distributions(files))
+    for path in [op.join(tmpdir, "img"), "shub:/" + location]:
+        files = [path, 'non-existent-image']
+        dist, remaining_files = next(tracer.identify_distributions(files))
 
-    assert dist.images[0].md5 == 'ed9755a0871f04db3e14971bec56a33f'
-    assert dist.images[0].bootstrap == 'docker'
-    assert dist.images[0].maintainer == 'vanessasaur'
-    assert dist.images[0].deffile == 'Singularity'
-    assert dist.images[0].schema_version == '1.0'
-    assert dist.images[0].build_date == '2017-10-15T12:52:56+00:00'
-    assert dist.images[0].build_size == '333MB'
-    assert dist.images[0].singularity_version == '2.4-feature-squashbuild-secbuild.g780c84d'
-    assert dist.images[0].base_image == 'ubuntu:14.04'
-    assert 'non-existent-image' in remaining_files
-
-    # Run tracer against a Singularity Hub url
-    files = ['shub:/GodloveD/lolcow@a59d8de3121579fe9c95ab8af0297c2e3aefd827']
-    dist, remaining_files = next(tracer.identify_distributions(files))
-    assert dist.images[0].md5 == 'ee4aae1ea378ad7c0299b308c703187a'
-    assert dist.images[0].bootstrap == 'docker'
-    assert dist.images[0].deffile == 'Singularity'
-    assert dist.images[0].schema_version == '1.0'
-    assert dist.images[0].build_date == '2017-10-17T19:23:53+00:00'
-    assert dist.images[0].build_size == '336MB'
-    assert dist.images[0].singularity_version == '2.4-feature-squashbuild-secbuild.g217367c'
-    assert dist.images[0].base_image == 'ubuntu:16.04'
-    assert dist.images[0].url == 'shub://GodloveD/lolcow@a59d8de3121579fe9c95ab8af0297c2e3aefd827'
+        assert dist.images[0].md5 == 'ed9755a0871f04db3e14971bec56a33f'
+        assert dist.images[0].bootstrap == 'docker'
+        assert dist.images[0].maintainer == 'vanessasaur'
+        assert dist.images[0].deffile == 'Singularity'
+        assert dist.images[0].schema_version == '1.0'
+        assert dist.images[0].build_date == '2017-10-15T12:52:56+00:00'
+        assert dist.images[0].build_size == '333MB'
+        assert dist.images[0].singularity_version == '2.4-feature-squashbuild-secbuild.g780c84d'
+        assert dist.images[0].base_image == 'ubuntu:14.04'
+        assert 'non-existent-image' in remaining_files

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -26,7 +26,8 @@ def test_singularity_trace(tmpdir):
     tmpdir = str(tmpdir)
     # Download and set up singularity image file
     runner = Runner(cwd=tmpdir)
-    location = 'vsoch/hello-world@42e1f04ed80217895f8c960bdde6bef4d34fab59'
+    expected_md5sum = "ed9755a0871f04db3e14971bec56a33f"
+    location = 'vsoch/hello-world@' + expected_md5sum
     runner.run(['singularity', 'pull', '--name', 'img', 'shub://' + location])
 
     # Test tracer class
@@ -36,7 +37,7 @@ def test_singularity_trace(tmpdir):
         files = [path, 'non-existent-image']
         dist, remaining_files = next(tracer.identify_distributions(files))
         img_info = dist.images[0]
-        assert img_info.md5 == 'ed9755a0871f04db3e14971bec56a33f'
+        assert img_info.md5 == expected_md5sum
         assert img_info.bootstrap == 'docker'
         assert img_info.maintainer == 'vanessasaur'
         assert img_info.deffile == 'Singularity'

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -9,13 +9,19 @@
 
 import os.path as op
 
+import pytest
+
 from ...cmd import Runner
 from ...distributions.singularity import SingularityTracer
+from ...support.external_versions import external_versions
 from ...tests.skip import mark
 
 
 @mark.skipif_no_network
 @mark.skipif_no_singularity
+@pytest.mark.xfail(
+    external_versions["cmd:singularity"] >= '3',
+    reason="Pulling with @hash fails with Singularity v3 (gh-406)")
 def test_singularity_trace(tmpdir):
     tmpdir = str(tmpdir)
     # Download and set up singularity image file

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -19,11 +19,10 @@ from ...tests.skip import mark
 def test_singularity_trace(tmpdir):
     tmpdir = str(tmpdir)
     # Download and set up singularity image file
-    runner = Runner()
-    runner.run(['singularity', 'pull',
+    runner = Runner(cwd=tmpdir)
+    runner.run(['singularity', 'pull', '--name', 'img',
         'shub://vsoch/hello-world@42e1f04ed80217895f8c960bdde6bef4d34fab59'])
     image_file = op.join(tmpdir, "img")
-    os.rename('vsoch-hello-world-master-latest.simg', image_file)
 
     # Test tracer class
     tracer = SingularityTracer()

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -26,8 +26,8 @@ def test_singularity_trace(tmpdir):
     tmpdir = str(tmpdir)
     # Download and set up singularity image file
     runner = Runner(cwd=tmpdir)
-    expected_md5sum = "ed9755a0871f04db3e14971bec56a33f"
-    location = 'vsoch/hello-world@' + expected_md5sum
+    expected_md5sum = "96563a1ee2a3d9dbd082efb8d263fc09"
+    location = "singularityhub/busybox@{}" + expected_md5sum
     runner.run(['singularity', 'pull', '--name', 'img', 'shub://' + location])
 
     # Test tracer class
@@ -39,11 +39,11 @@ def test_singularity_trace(tmpdir):
         img_info = dist.images[0]
         assert img_info.md5 == expected_md5sum
         assert img_info.bootstrap == 'docker'
-        assert img_info.maintainer == 'vanessasaur'
+        assert img_info.maintainer is None
         assert img_info.deffile == 'Singularity'
         assert img_info.schema_version == '1.0'
-        assert img_info.build_date == '2017-10-15T12:52:56+00:00'
-        assert img_info.build_size == '333MB'
-        assert img_info.singularity_version == '2.4-feature-squashbuild-secbuild.g780c84d'
-        assert img_info.base_image == 'ubuntu:14.04'
+        assert img_info.build_date == '2017-10-18T16:52:17+00:00'
+        assert img_info.build_size == '180MB'
+        assert img_info.singularity_version == '2.4-feature-squashbuild-secbuild.g217367c'
+        assert img_info.base_image == "busybox"
         assert 'non-existent-image' in remaining_files

--- a/reproman/resource/singularity.py
+++ b/reproman/resource/singularity.py
@@ -32,11 +32,11 @@ class Singularity(Resource):
     """
 
     # Generic properties of any Resource
-    name = attrib()
+    name = attrib(default=attr.NOTHING)
+    image = attrib(doc="Base image filename or url", default=attr.NOTHING)
 
     # Container properties
     id = attrib()
-    image = attrib(doc="Base image filename or url")
     type = attrib(default='singularity')
 
     status = attrib()

--- a/reproman/resource/singularity.py
+++ b/reproman/resource/singularity.py
@@ -46,13 +46,7 @@ class Singularity(Resource):
         """
         Open a connection to the environment.
         """
-        version = external_versions["cmd:singularity"]
-        if version is None or version < "2.4":
-            msg = "Found version {}".format(version) if version else ""
-            # Running singularity instances and managing them didn't happen
-            # until version 2.4. See: https://singularity.lbl.gov/archive/
-            raise CommandError(msg="Singularity version >= 2.4 required." + msg)
-
+        external_versions.check("cmd:singularity", min_version="2.4")
         # Get instance info if we have one running.
         info = self.get_instance_info()
         if info:

--- a/reproman/resource/singularity.py
+++ b/reproman/resource/singularity.py
@@ -157,7 +157,7 @@ class Singularity(Resource):
         # The output of instance.list is a table with columns:
         #   DAEMON NAME, PID, and CONTAINER IMAGE
         # Daemon names are unique on each server.
-        for row in stdout.splitlines()[1:]:
+        for row in stdout.strip().splitlines()[1:]:
             items = row.split()
             if self.name == items[0] or self.id == "{0}-{1}".format(*items):
                 return {

--- a/reproman/resource/tests/test_singularity.py
+++ b/reproman/resource/tests/test_singularity.py
@@ -64,7 +64,6 @@ def test_singularity_resource_class():
         info = resource.get_instance_info()
         assert info['name'] == 'foo'
         assert re.match(r'^\d+$', info['pid'])
-        assert info['image'].endswith('.simg')
 
         # Test starting an instance.
         with pytest.raises(NotImplementedError):

--- a/reproman/resource/tests/test_singularity.py
+++ b/reproman/resource/tests/test_singularity.py
@@ -22,6 +22,11 @@ from ...tests.skip import mark
 from ...utils import swallow_logs
 
 
+def test_singularity_resource_image_required():
+    with pytest.raises(TypeError):
+        Singularity(name='foo')
+
+
 @mark.skipif_no_network
 @mark.skipif_no_singularity
 def test_singularity_resource_class():

--- a/reproman/resource/tests/test_singularity.py
+++ b/reproman/resource/tests/test_singularity.py
@@ -57,6 +57,12 @@ def test_singularity_resource_class(tmpdir):
         list(resource_duplicate.create())
         assert_in("Resource 'foo' already exists.", log.lines)
 
+        # But using a different name with the same image would work.
+        resource_nondup = Singularity(name="foo_nondup", image=image)
+        resource_nondup.connect()
+        resource_nondup.name = "foo_nondup"
+        resource_nondup.delete()
+
         # Test retrieving instance info.
         info = resource.get_instance_info()
         assert info['name'] == 'foo'

--- a/reproman/tests/fixtures.py
+++ b/reproman/tests/fixtures.py
@@ -110,14 +110,18 @@ def get_singularity_fixture(name=None, image="docker://python:2.7",
         A scope for the fixture according to `pytest.fixture` docs
     """
     @pytest.fixture(scope=scope)
-    def fixture():
+    def fixture(tmpdir_factory):
         skipif.no_network()
         skipif.no_singularity()
-        from reproman.resource.singularity import Singularity
-        resource = Singularity(name=name or str(uuid.uuid4().hex)[:11],
-                               image=image)
-        resource.connect()
-        list(resource.create())
+
+        # Change to a temporary directory so that we don't pollute the current
+        # directory with image files.
+        with chpwd(str(tmpdir_factory.mktemp("singularity-resource"))):
+            from reproman.resource.singularity import Singularity
+            resource = Singularity(name=name or str(uuid.uuid4().hex)[:11],
+                                   image=image)
+            resource.connect()
+            list(resource.create())
         yield resource
         resource.delete()
     return fixture


### PR DESCRIPTION
This PR includes various fixes and touch-ups to `{resource,distribution}/singularity.py` and their tests.  The more notable ones:

  * Fix IndexError when creating a Singularity resource and there are existing instances.

  * The Singularity resources image attribute is now required (rather than defaulting to None, which wasn't handled).

  * Testing should now work with Singularity v3, with one expected failure due to gh-406.

  * test_singularity_resource_class tries harder to clean up its test instances on failure and to not collide with existing instance names.
