### PR TITLE
BF: Correct reported resource types

### DIFF
--- a/reproman/interface/backend_parameters.py
+++ b/reproman/interface/backend_parameters.py
@@ -17,7 +17,7 @@ from logging import getLogger
 from reproman.dochelpers import exc_str
 from reproman.interface.base import Interface
 from reproman.resource import Resource
-from reproman.resource.base import ResourceManager
+from reproman.resource.base import discover_types
 from reproman.resource.base import get_resource_backends
 from reproman.support.constraints import EnsureStr
 from reproman.support.param import Parameter
@@ -27,12 +27,12 @@ lgr = getLogger('reproman.api.backend_parameters')
 
 
 def get_resource_classes(names=None):
-    for name in names or ResourceManager._discover_types():
+    for name in names or discover_types():
         try:
             module = import_module('reproman.resource.{}'.format(name))
         except ImportError as exc:
             import difflib
-            known = ResourceManager._discover_types()
+            known = discover_types()
             suggestions = difflib.get_close_matches(name, known)
             lgr.warning(
                 "Failed to import resource %s: %s. %s: %s",
@@ -67,7 +67,7 @@ class BackendParameters(Interface):
 
     @staticmethod
     def __call__(backends=None):
-        backends = backends or ResourceManager._discover_types()
+        backends = backends or discover_types()
         for backend, cls in get_resource_classes(backends):
             param_doc = "\n".join(
                 ["  {}: {}".format(p, pdoc)

--- a/reproman/interface/backend_parameters.py
+++ b/reproman/interface/backend_parameters.py
@@ -29,7 +29,8 @@ lgr = getLogger('reproman.api.backend_parameters')
 def get_resource_classes(names=None):
     for name in names or discover_types():
         try:
-            module = import_module('reproman.resource.{}'.format(name))
+            module = import_module('reproman.resource.{}'
+                                   .format(name.replace('-', '_')))
         except ImportError as exc:
             import difflib
             known = discover_types()
@@ -42,7 +43,7 @@ def get_resource_classes(names=None):
                 ', '.join(suggestions or known))
             continue
 
-        class_name = ''.join([token.capitalize() for token in name.split('_')])
+        class_name = ''.join([token.capitalize() for token in name.split('-')])
         cls = getattr(module, class_name)
         if issubclass(cls, Resource):
             yield name, cls

--- a/reproman/interface/backend_parameters.py
+++ b/reproman/interface/backend_parameters.py
@@ -11,7 +11,6 @@
 
 __docformat__ = 'restructuredtext'
 
-from importlib import import_module
 from logging import getLogger
 
 from reproman.dochelpers import exc_str
@@ -19,7 +18,9 @@ from reproman.interface.base import Interface
 from reproman.resource import Resource
 from reproman.resource.base import discover_types
 from reproman.resource.base import get_resource_backends
+from reproman.resource.base import get_resource_class
 from reproman.support.constraints import EnsureStr
+from reproman.support.exceptions import ResourceError
 from reproman.support.param import Parameter
 
 
@@ -29,28 +30,17 @@ lgr = getLogger('reproman.api.backend_parameters')
 def get_resource_classes(names=None):
     for name in names or discover_types():
         try:
-            module = import_module('reproman.resource.{}'
-                                   .format(name.replace('-', '_')))
-        except ImportError as exc:
-            import difflib
-            known = discover_types()
-            suggestions = difflib.get_close_matches(name, known)
-            lgr.warning(
-                "Failed to import resource %s: %s. %s: %s",
-                name,
-                exc_str(exc),
-                "Similar backends" if suggestions else "Known backends",
-                ', '.join(suggestions or known))
+            cls = get_resource_class(name)
+        except ResourceError as exc:
+            lgr.warning(exc_str(exc))
             continue
 
-        class_name = ''.join([token.capitalize() for token in name.split('-')])
-        cls = getattr(module, class_name)
         if issubclass(cls, Resource):
             yield name, cls
         else:
-            lgr.debug("Skipping %s.%s because it is not a Resource. "
+            lgr.debug("Skipping %s because it is not a Resource. "
                       "Consider moving away",
-                      module, class_name)
+                      cls)
 
 
 class BackendParameters(Interface):

--- a/reproman/interface/create.py
+++ b/reproman/interface/create.py
@@ -12,12 +12,9 @@
 __docformat__ = 'restructuredtext'
 
 from .base import Interface
-import reproman.interface.base # Needed for test patching
 from ..support.param import Parameter
 from ..support.constraints import EnsureStr
-from ..support.exceptions import ResourceError
 from ..resource import get_manager
-from ..dochelpers import exc_str
 from ..utils import parse_kv_list
 
 

--- a/reproman/interface/tests/test_backend_parameters.py
+++ b/reproman/interface/tests/test_backend_parameters.py
@@ -34,6 +34,6 @@ def test_backend_parameters_all():
         backend_parameters()
     assert "host:" in out.getvalue()
     if "boto3" in external_versions:
-        assert "aws_ec2" in out.getvalue()
+        assert "aws-ec2" in out.getvalue()
     else:
-        assert "aws_ec2" not in out.getvalue()
+        assert "aws-ec2" not in out.getvalue()

--- a/reproman/resource/base.py
+++ b/reproman/resource/base.py
@@ -42,7 +42,7 @@ def discover_types():
         f_ = op.basename(f)
         if f_ in ('base.py',) or f_.startswith('_'):
             continue
-        l.append(f_[:-3])
+        l.append(f_[:-3].replace('_', '-'))
     return sorted(l)
 
 

--- a/reproman/resource/base.py
+++ b/reproman/resource/base.py
@@ -29,6 +29,23 @@ import logging
 lgr = logging.getLogger('reproman.resource.base')
 
 
+def discover_types():
+    """Discover resource types by inspecting the resource directory files.
+
+    Returns
+    -------
+    string list
+        List of resource identifiers extracted from file names.
+    """
+    l = []
+    for f in glob(op.join(op.dirname(__file__), '*.py')):
+        f_ = op.basename(f)
+        if f_ in ('base.py',) or f_.startswith('_'):
+            continue
+        l.append(f_[:-3])
+    return sorted(l)
+
+
 def get_required_fields(cls):
     """Return the mandatory fields for a resource class.
     """
@@ -138,7 +155,7 @@ class ResourceManager(object):
             # anything just in case.
             try:
                 msg = exc_str(exc)
-                known = ResourceManager._discover_types()
+                known = discover_types()
                 if module_name not in known:
                     msg += ". Known ones are: {}".format(", ".join(known))
             except Exception as exc2:
@@ -155,24 +172,6 @@ class ResourceManager(object):
             # unknown backend parameter.
             raise
         return instance
-
-    # TODO: Following methods might better be in their own class
-    @staticmethod
-    def _discover_types():
-        """Discover resource types by inspecting the resource directory files.
-
-        Returns
-        -------
-        string list
-            List of resource identifiers extracted from file names.
-        """
-        l = []
-        for f in glob(op.join(op.dirname(__file__), '*.py')):
-            f_ = op.basename(f)
-            if f_ in ('base.py',) or f_.startswith('_'):
-                continue
-            l.append(f_[:-3])
-        return sorted(l)
 
     def _find_resources(self, resref, resref_type):
         def match_name(inventory_item):

--- a/reproman/resource/base.py
+++ b/reproman/resource/base.py
@@ -46,6 +46,39 @@ def discover_types():
     return sorted(l)
 
 
+def get_resource_class(name):
+    module_name = name.replace('-', '_')
+    try:
+        module = import_module('reproman.resource.{}'.format(module_name))
+    except Exception as exc:
+        # Typically it should be an ImportError, but let's catch and recast
+        # anything just in case.
+        import difflib
+        try:
+            msg = exc_str(exc)
+            known = discover_types()
+            suggestions = difflib.get_close_matches(name, known)
+            if module_name not in known:
+                msg += (
+                    ". {}: {}"
+                    .format("Similar backends" if suggestions else "Known backends",
+                            ', '.join(suggestions or known)))
+        except Exception as exc2:
+            msg += ".  Failed to discover resource types: " + exc_str(exc2)
+        raise ResourceError(
+            "Failed to import resource: {}".format(msg)
+        )
+
+    class_name = ''.join([token.capitalize() for token in name.split('-')])
+    try:
+        cls = getattr(module, class_name)
+    except AttributeError as exc:
+        raise ResourceError(
+            "Failed to find {} in {}: {}"
+            .format(class_name, module, exc_str(exc)))
+    return cls
+
+
 def get_required_fields(cls):
     """Return the mandatory fields for a resource class.
     """
@@ -146,24 +179,7 @@ class ResourceManager(object):
             raise MissingConfigError("Resource 'type' parameter missing for resource.")
 
         type_ = config['type']
-        module_name = type_.replace('-', '_')
-        class_name = ''.join([token.capitalize() for token in type_.split('-')])
-        try:
-            module = import_module('reproman.resource.{}'.format(module_name))
-        except Exception as exc:
-            # Typically it should be an ImportError, but let's catch and recast
-            # anything just in case.
-            try:
-                msg = exc_str(exc)
-                known = discover_types()
-                if module_name not in known:
-                    msg += ". Known ones are: {}".format(", ".join(known))
-            except Exception as exc2:
-                msg += ".  Failed to discover resource types: " + exc_str(exc2)
-            raise ResourceError(
-                "Failed to import resource: {}".format(msg)
-            )
-        cls = getattr(module, class_name)
+        cls = get_resource_class(type_)
         try:
             instance = cls(**config)
         except TypeError:

--- a/reproman/resource/base.py
+++ b/reproman/resource/base.py
@@ -47,6 +47,13 @@ def discover_types():
 
 
 def get_resource_class(name):
+    if '_' in name:
+        known = discover_types()
+        hyph_name = name.replace('_', '-')
+        if name not in known and hyph_name in known:
+            raise ResourceError(
+                "'{}' not a known backend. Did you mean '{}'?"
+                .format(name, hyph_name))
     module_name = name.replace('-', '_')
     try:
         module = import_module('reproman.resource.{}'.format(module_name))

--- a/reproman/resource/base.py
+++ b/reproman/resource/base.py
@@ -146,7 +146,7 @@ class ResourceManager(object):
             raise MissingConfigError("Resource 'type' parameter missing for resource.")
 
         type_ = config['type']
-        module_name = '_'.join(type_.split('-'))
+        module_name = type_.replace('-', '_')
         class_name = ''.join([token.capitalize() for token in type_.split('-')])
         try:
             module = import_module('reproman.resource.{}'.format(module_name))

--- a/reproman/resource/tests/test_base.py
+++ b/reproman/resource/tests/test_base.py
@@ -12,6 +12,7 @@ import pytest
 from reproman.config import ConfigManager
 from reproman.resource.base import ResourceManager
 from reproman.resource.base import backend_check_parameters
+from reproman.resource.base import get_resource_class
 from reproman.resource.shell import Shell
 from reproman.support.exceptions import MissingConfigError
 from reproman.support.exceptions import MultipleResourceMatches
@@ -202,3 +203,29 @@ def test_create_includes_config(tmpdir):
             manager.create("myssh", "ssh")
             factory.assert_called_with(
                 {"host": "myhost", "name": "myssh", "type": "ssh"})
+
+
+def test_get_resource_class():
+    from reproman.resource.shell import Shell
+    assert get_resource_class("shell") == Shell
+
+    # If we can't find the resource, we suggest near-hits.
+    with pytest.raises(ResourceError) as exc:
+        get_resource_class("shll")
+    assert "shell" in str(exc.value)
+
+    # We raise a resource error if some other failure happens while trying to
+    # discover resource types.
+    with pytest.raises(ResourceError) as exc:
+        def fail():
+            raise Exception("some failure")
+        with patch("reproman.resource.base.discover_types",
+                   fail):
+            get_resource_class("shll")
+    assert "Failed to discover" in str(exc.value)
+
+    # We raise a resource error if we can find a module in reproman/resource/
+    # but it doesn't have a corresponding resource class.
+    with pytest.raises(ResourceError) as exc:
+        get_resource_class("base")
+    assert "Failed to find" in str(exc)

--- a/reproman/resource/tests/test_base.py
+++ b/reproman/resource/tests/test_base.py
@@ -229,3 +229,9 @@ def test_get_resource_class():
     with pytest.raises(ResourceError) as exc:
         get_resource_class("base")
     assert "Failed to find" in str(exc)
+
+    # We recognize when s/_/-/ would give an existing class and provide an
+    # informative error.
+    with pytest.raises(ResourceError) as exc:
+        get_resource_class("docker_container")
+    assert "docker-container" in str(exc)


### PR DESCRIPTION
This PR corrects spots where we output an unusable, underscore-delimited resource type instead of a hyphenated one (e.g., docker_container instead of docker-container).  It also improves the error message when a underscore-delimited form is used.
