### PR TITLE
ENH: resource: Tolerate unknown resource parameters in inventory

### DIFF
--- a/reproman/conftest.py
+++ b/reproman/conftest.py
@@ -11,6 +11,7 @@
 # Some commonly used fixtures
 
 from reproman.formats.tests.fixtures import demo1_spec, reprozip_spec2
+from reproman.tests.fixtures import resource_manager_fixture
 
 import pytest
 
@@ -29,3 +30,9 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if "integration" in item.keywords:
             item.add_marker(skip_integration)
+
+
+# This is useful for tests that need a ResourceManager instance but do not need
+# any resources and don't plan on modifying the on-disk inventory. If you do
+# need to modify the resources, use `resource_manager_fixture` directly.
+resman = resource_manager_fixture(resources={}, scope="session")

--- a/reproman/resource/base.py
+++ b/reproman/resource/base.py
@@ -99,6 +99,62 @@ def get_resource_backends(cls):
             if "doc" in b.metadata}
 
 
+def classify_keys(cls, keys):
+    """Classify `keys` according to the parameters of resource `cls`.
+
+    Parameters
+    ----------
+    cls : Resource object
+    keys : iterable
+       Keys to classify.
+
+    Returns
+    -------
+    A dictionary where each of `keys` is classified into one of the following
+    categories:
+      - required
+        a parameter that must be specified when instantiating the class (either
+        by us or the user)
+      - opt_user
+        a optional parameter that is exposed to the user (i.e. a field that has
+        a default value and "doc" metadata)
+      - opt_internal
+        a unexposed optional parameter (i.e. a field with a default value but
+        with no "doc" metadata) that should not be set by the user (e.g.,
+        status)
+      - unknown
+        a parameter that doesn't fall into any of the above categories
+
+    Raises
+    ------
+    A ResourceError if a required parameter isn't included in `keys`.
+    """
+    all_fields = {f.name for f in attr.fields(cls)}
+    required_params = get_required_fields(cls)
+    required_seen = set()
+    known = get_resource_backends(cls)
+    cats = {"required": [], "opt_user": [], "opt_internal": [], "unknown": []}
+    for key in keys:
+        if key in required_params:
+            required_seen.add(key)
+            cat = "required"
+        elif key in known:
+            cat = "opt_user"
+        elif key in all_fields:
+            # These are attributes like id and status.
+            cat = "opt_internal"
+        else:
+            cat = "unknown"
+        cats[cat].append(key)
+
+    required_missing = required_params.difference(required_seen)
+    if required_missing:
+        raise ResourceError("Missing required backend parameters: {}"
+                            .format(",".join(required_missing)))
+
+    return cats
+
+
 def backend_check_parameters(cls, keys):
     """Check whether any backend parameter keys are unknown.
 
@@ -112,14 +168,10 @@ def backend_check_parameters(cls, keys):
     ------
     ResourceError on the first unknown key encountered.
     """
-    required_params = get_required_fields(cls)
-    for req_param in required_params:
-        if req_param not in keys:
-            raise ResourceError(
-                "Missing required backend parameter: " + req_param)
-    known = get_resource_backends(cls)
-    for key in keys:
-        if key not in known and key not in required_params:
+    unknown = classify_keys(cls, keys)["unknown"]
+    if unknown:
+        known = get_resource_backends(cls)
+        for key in unknown:
             if known:
                 import difflib
 

--- a/reproman/resource/base.py
+++ b/reproman/resource/base.py
@@ -150,7 +150,7 @@ def classify_keys(cls, keys):
     required_missing = required_params.difference(required_seen)
     if required_missing:
         raise ResourceError("Missing required backend parameters: {}"
-                            .format(",".join(required_missing)))
+                            .format(", ".join(sorted(required_missing))))
 
     return cats
 

--- a/reproman/resource/tests/test_aws_ec2.py
+++ b/reproman/resource/tests/test_aws_ec2.py
@@ -12,13 +12,12 @@ from unittest.mock import patch, call, MagicMock
 from ...utils import swallow_logs
 from ...tests.utils import assert_in
 from ...tests.skip import mark
-from ..base import ResourceManager
 from ..ssh import SSH
 
 pytestmark = mark.skipif_no_aws_dependencies
 
 
-def test_awsec2_class():
+def test_awsec2_class(resman):
 
     with patch('boto3.resource') as client, \
             patch.object(SSH, 'get_session', return_value='started_session'), \
@@ -34,7 +33,7 @@ def test_awsec2_class():
             'access_key_id': 'my-aws-access-key-id',
             'secret_access_key': 'my-aws-secret-access-key-id'
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         resource.connect()
         assert resource.id is None
         assert resource.status is None
@@ -58,7 +57,7 @@ def test_awsec2_class():
             'access_key_id': 'my-aws-access-key-id',
             'secret_access_key': 'my-aws-secret-access-key-id'
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         try:
             resource.connect()
         except Exception as e:
@@ -80,7 +79,7 @@ def test_awsec2_class():
             'key_name': 'my-ssh-key',
             'key_filename': '/home/me/.ssh/id_rsa'
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         resource.connect()
         assert resource.image == 'ami-c8580bdf'
         assert resource.id == 'i-00002777d52482d9c'
@@ -117,7 +116,7 @@ def test_awsec2_class():
             'key_name': 'my-ssh-key',
             'key_filename': '/home/me/.ssh/id_rsa'
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         resource.connect()
         # Test retrieving more than one yield from the create method
         create_generator = resource.create()

--- a/reproman/resource/tests/test_base.py
+++ b/reproman/resource/tests/test_base.py
@@ -31,6 +31,26 @@ def test_resource_manager_factory_unkown(resman):
         resman.factory({"type": "not really a type"})
 
 
+def test_resource_manager_factory_missing_required(resman):
+    with pytest.raises(ResourceError):
+        resman.factory({"type": "shell"})
+
+
+@pytest.mark.parametrize("type_", ["shell", "ssh"])
+def test_resource_manager_factory_invalid_param(resman, type_):
+    config = {"type": type_,
+              "id": "id",
+              "name": "name",
+              # All of the below are invalid in the case of shell. For ssh,
+              # "other" is invalid.
+              "host": "host",
+              "port": "port",
+              "other": "doesntmatter"}
+
+    with pytest.raises(ResourceError):
+        resman.factory(config)
+
+
 def test_backend_check_parameters_no_known():
     with pytest.raises(ResourceError) as exc:
         backend_check_parameters(Shell,

--- a/reproman/resource/tests/test_base.py
+++ b/reproman/resource/tests/test_base.py
@@ -11,6 +11,7 @@ import pytest
 
 from reproman.config import ConfigManager
 from reproman.resource.base import ResourceManager
+from reproman.resource.base import Resource
 from reproman.resource.base import backend_check_parameters
 from reproman.resource.base import get_resource_class
 from reproman.resource.shell import Shell
@@ -49,6 +50,9 @@ def test_resource_manager_factory_invalid_param(resman, type_):
 
     with pytest.raises(ResourceError):
         resman.factory(config)
+
+    res = resman.factory(config, strict=False)
+    assert isinstance(res, Resource)
 
 
 def test_backend_check_parameters_no_known():

--- a/reproman/resource/tests/test_base.py
+++ b/reproman/resource/tests/test_base.py
@@ -21,14 +21,14 @@ from reproman.support.exceptions import ResourceError
 from reproman.tests.skip import mark
 
 
-def test_resource_manager_factory_missing_type():
+def test_resource_manager_factory_missing_type(resman):
     with pytest.raises(MissingConfigError):
-        ResourceManager.factory({})
+        resman.factory({})
 
 
-def test_resource_manager_factory_unkown():
+def test_resource_manager_factory_unkown(resman):
     with pytest.raises(ResourceError):
-        ResourceManager.factory({"type": "not really a type"})
+        resman.factory({"type": "not really a type"})
 
 
 def test_backend_check_parameters_no_known():

--- a/reproman/resource/tests/test_docker_container.py
+++ b/reproman/resource/tests/test_docker_container.py
@@ -13,7 +13,6 @@ from ...utils import merge_dicts
 from ...utils import swallow_logs
 from ...tests.utils import assert_in
 from ...tests.skip import mark
-from ..base import ResourceManager
 from ...support.exceptions import ResourceError
 from ...consts import TEST_SSH_DOCKER_DIGEST
 
@@ -30,7 +29,7 @@ setup_ubuntu = get_docker_fixture(
 
 
 @mark.skipif_no_docker_dependencies
-def test_dockercontainer_class():
+def test_dockercontainer_class(resman):
 
     with patch('docker.Client') as client, \
         patch('dockerpty.start') as dockerpty, \
@@ -74,7 +73,7 @@ def test_dockercontainer_class():
             'name': 'non-existent-resource',
             'type': 'docker-container'
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         resource.connect()
         assert resource.id is None
         assert resource.status is None
@@ -84,7 +83,7 @@ def test_dockercontainer_class():
             'name': 'duplicate-resource-name',
             'type': 'docker-container'
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         with raises(ResourceError) as ecm:
             resource.connect()
         assert ecm.value.args[0].startswith("Multiple container matches found")
@@ -96,7 +95,7 @@ def test_dockercontainer_class():
             'engine_url': 'tcp://127.0.0.1:2375',
             'seccomp_unconfined': True
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         resource.connect()
         assert resource.image == 'ubuntu:latest'
         assert resource.engine_url == 'tcp://127.0.0.1:2375'
@@ -117,7 +116,7 @@ def test_dockercontainer_class():
             'type': 'docker-container',
             'engine_url': 'tcp://127.0.0.1:2375'
         }
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         resource.connect()
         results = merge_dicts(resource.create())
         assert results['id'] == '18b31b30e3a5'

--- a/reproman/resource/tests/test_shell.py
+++ b/reproman/resource/tests/test_shell.py
@@ -17,13 +17,12 @@ from unittest.mock import patch, call
 from ...utils import merge_dicts
 from ...utils import swallow_logs
 from ...tests.utils import assert_in
-from ..base import ResourceManager
 from ...cmd import Runner
 from ..shell import Shell, ShellSession
 from .test_session import check_session_passing_envvars
 
 
-def test_shell_class():
+def test_shell_class(resman):
 
     with patch.object(Runner, 'run', return_value='installed package') as runner, \
             swallow_logs(new_level=logging.DEBUG) as log:
@@ -33,7 +32,7 @@ def test_shell_class():
             'name': 'my-shell',
             'type': 'shell'
         }
-        shell = ResourceManager.factory(config)
+        shell = resman.factory(config)
 
         command = ['apt-get', 'install', 'bc']
         shell.add_command(command)
@@ -127,13 +126,13 @@ def test_session_passing_envvars():
     check_session_passing_envvars(ShellSession())
 
 
-def test_shell_resource():
+def test_shell_resource(resman):
 
     config = {
         'name': 'test-ssh-resource',
         'type': 'shell'
     }
-    resource = ResourceManager.factory(config)
+    resource = resman.factory(config)
 
     status = merge_dicts(resource.create())
     assert re.match('\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$', status['id']) is not None

--- a/reproman/resource/tests/test_ssh.py
+++ b/reproman/resource/tests/test_ssh.py
@@ -20,7 +20,6 @@ from ...utils import merge_dicts
 from ...utils import swallow_logs
 from ...tests.utils import assert_in
 from ...tests.skip import mark
-from ..base import ResourceManager
 from reproman.tests.fixtures import get_docker_fixture
 from ...consts import TEST_SSH_DOCKER_DIGEST
 
@@ -48,7 +47,7 @@ def test_setup_ssh(setup_ssh):
     assert setup_ssh['custom']['host'] == 'localhost'
 
 
-def test_ssh_class(setup_ssh, resource_test_dir):
+def test_ssh_class(setup_ssh, resource_test_dir, resman):
     with swallow_logs(new_level=logging.DEBUG) as log:
 
         # Test connecting to test SSH server.
@@ -58,7 +57,7 @@ def test_ssh_class(setup_ssh, resource_test_dir):
             type='ssh',
             **setup_ssh['custom']
         )
-        resource = ResourceManager.factory(config)
+        resource = resman.factory(config)
         updated_config = merge_dicts(resource.create())
         config.update(updated_config)
         assert re.match('\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$',
@@ -116,7 +115,7 @@ def test_ssh_class(setup_ssh, resource_test_dir):
             session._execute_command('non-existent-command', cwd='/path')
 
 
-def test_ssh_resource(setup_ssh):
+def test_ssh_resource(setup_ssh, resman):
 
     config = {
         'name': 'ssh-test-resource',
@@ -125,7 +124,7 @@ def test_ssh_resource(setup_ssh):
         'user': 'root',
         'port': 49000
     }
-    resource = ResourceManager.factory(config)
+    resource = resman.factory(config)
     resource.connect(password='root')
 
     with pytest.raises(NotImplementedError):


### PR DESCRIPTION
If we encounter an invalid parameter when instantiating resources from the inventory, issue a warning and filter out the parameter rather than raising a `ResourceError`.

Closes #171.
