### PR TITLE
TST: Mark failures due to offline Singularity Hub as expected

### DIFF
--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -19,6 +19,7 @@ from ...tests.skip import mark
 
 @mark.skipif_no_network
 @mark.skipif_no_singularity
+@pytest.mark.xfail(reason="Singularity Hub is down")
 @pytest.mark.xfail(
     external_versions["cmd:singularity"] >= '3',
     reason="Pulling with @hash fails with Singularity v3 (gh-406)")

--- a/reproman/distributions/tests/test_singularity.py
+++ b/reproman/distributions/tests/test_singularity.py
@@ -19,7 +19,7 @@ from ...tests.skip import mark
 
 @mark.skipif_no_network
 @mark.skipif_no_singularity
-@pytest.mark.xfail(reason="Singularity Hub is down")
+@pytest.mark.xfail(reason="Singularity Hub is down", run=False)
 @pytest.mark.xfail(
     external_versions["cmd:singularity"] >= '3',
     reason="Pulling with @hash fails with Singularity v3 (gh-406)")

--- a/reproman/resource/tests/test_singularity.py
+++ b/reproman/resource/tests/test_singularity.py
@@ -29,7 +29,7 @@ def test_singularity_resource_image_required():
         Singularity(name='foo')
 
 
-@pytest.mark.xfail(reason="Singularity Hub is down")
+@pytest.mark.xfail(reason="Singularity Hub is down", run=False)
 @mark.skipif_no_network
 @mark.skipif_no_singularity
 def test_singularity_resource_class(tmpdir):

--- a/reproman/resource/tests/test_singularity.py
+++ b/reproman/resource/tests/test_singularity.py
@@ -29,6 +29,7 @@ def test_singularity_resource_image_required():
         Singularity(name='foo')
 
 
+@pytest.mark.xfail(reason="Singularity Hub is down")
 @mark.skipif_no_network
 @mark.skipif_no_singularity
 def test_singularity_resource_class(tmpdir):

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -322,7 +322,7 @@ def test_orc_datalad_run_results_missing(job_spec, dataset, shell):
             orc.fetch()
 
 
-@pytest.mark.xfail(reason="Singularity Hub is down")
+@pytest.mark.xfail(reason="Singularity Hub is down", run=False)
 @pytest.mark.integration
 @pytest.mark.parametrize("orc_class",
                          [orcs.DataladPairRunOrchestrator,

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -322,6 +322,7 @@ def test_orc_datalad_run_results_missing(job_spec, dataset, shell):
             orc.fetch()
 
 
+@pytest.mark.xfail(reason="Singularity Hub is down")
 @pytest.mark.integration
 @pytest.mark.parametrize("orc_class",
                          [orcs.DataladPairRunOrchestrator,


### PR DESCRIPTION
Singularity Hub has been down for a while.  Mark the tests that fail
because of this as expected failures so that we don't have to look
into each Travis build to make sure that the only failures are the
Singularity Hub-related tests.