### PR TITLE
parse_kv_list: Improve error message for invalid key=value pair

### DIFF
--- a/reproman/tests/test_utils.py
+++ b/reproman/tests/test_utils.py
@@ -572,7 +572,7 @@ def test_merge_dicts():
     assert merge_dicts([{1: 1}, {2: 2}, {1: 3}]) == {1: 3, 2: 2}
 
 
-def test_parse_backend_parameters():
+def test_parse_kv_list():
     for value, expected in [(["a=b"], {"a": "b"}),
                             (["a="], {"a": ""}),
                             (["a=c=d"], {"a": "c=d"}),

--- a/reproman/tests/test_utils.py
+++ b/reproman/tests/test_utils.py
@@ -572,6 +572,13 @@ def test_merge_dicts():
     assert merge_dicts([{1: 1}, {2: 2}, {1: 3}]) == {1: 3, 2: 2}
 
 
+@pytest.mark.parametrize("value", [["ab"], ["a=b", "c"]])
+def test_parse_kv_list_invalid(value):
+    with pytest.raises(ValueError) as exc:
+        assert parse_kv_list(value)
+    assert "key=value" in str(exc.value)
+
+
 def test_parse_kv_list():
     for value, expected in [(["a=b"], {"a": "b"}),
                             (["a="], {"a": ""}),

--- a/reproman/utils.py
+++ b/reproman/utils.py
@@ -1426,11 +1426,22 @@ def parse_kv_list(params):
     Returns
     -------
     A mapping from backend key to value.
+
+    Raises
+    ------
+    ValueError if item in `params` does not match expected "key=value" format.
     """
     if isinstance(params, collections.Mapping):
         res = params
     elif params:
-        res = dict(p.split("=", 1) for p in params)
+        def check_fmt(item):
+            if "=" not in item:
+                raise ValueError(
+                    "Expected 'key=value' format but got '{}'"
+                    .format(item))
+            return item
+
+        res = dict(p.split("=", 1) for p in map(check_fmt, params))
     else:
         res = {}
     return res


### PR DESCRIPTION
`run` and `create` use parse_kv_list() to parse key-value pairs
provided on the command line.  If a caller doesn't use the expected
"key=value" form, we fail unhelpfully within parse_kv_list():

    dictionary update sequence element #0 has length 1; 2 is required

Say

    Expected 'key=value' format but got 'blahbert'

instead.
