### PR TITLE
BF: conda: Temporary pin version in miniconda URL

### DIFF
--- a/reproman/distributions/conda.py
+++ b/reproman/distributions/conda.py
@@ -85,7 +85,9 @@ def get_miniconda_url(conda_platform, python_version):
         raise ValueError("Unsupported platform %s for conda installation" %
                          conda_platform)
     platform += "-x86_64" if ("64" in conda_platform) else "-x86"
-    return "https://repo.continuum.io/miniconda/Miniconda%s-latest-%s.sh" \
+    # FIXME: We need to update this our conda tracer to work with conda's newer
+    # than 4.6.14. See gh-443.
+    return "https://repo.continuum.io/miniconda/Miniconda%s-4.6.14-%s.sh" \
                     % (python_version[0], platform)
 
 

--- a/reproman/distributions/tests/test_conda.py
+++ b/reproman/distributions/tests/test_conda.py
@@ -33,11 +33,11 @@ def test_get_conda_platform_from_python():
 
 def test_get_miniconda_url():
     assert get_miniconda_url("linux-64", "2.7") == \
-           "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh"
+           "https://repo.continuum.io/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh"
     assert get_miniconda_url("linux-32", "3.4") == \
-           "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh"
+           "https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86.sh"
     assert get_miniconda_url("osx-64", "3.5.1") == \
-           "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh"
+           "https://repo.continuum.io/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh"
 
 
 def test_get_simple_python_version():


### PR DESCRIPTION
Our test suite is failing with the latest miniconda version (gh-443).
The initial issue looks to be a version conflict.  A reasonable
approach would be to just bump all versions in that test because
understanding or resolving this specific set of incompatibilities
between old software versions isn't worth the time or effort.

But that won't work because our distributions.conda isn't compatible
with the latest conda in at least two ways.  We use an environment
file that doesn't have an extension that conda now expects.  That's an
easy fix, and there's a patch in gh-443.  The bigger issue is that
environments seem to no longer have their own bin/conda unless conda
is explicitly installed in the environment.  (This mirrors the then
seemingly hard-to-trigger problem initially described in gh-173.)  As
a result, our method for identifying an environment's root prefix is
broken.  Based on a quick scan of envs/NAME/, there may no longer be
an easy way to map from an environment to its root prefix.

Given that there doesn't seem to be a quick fix and an always failing
test suite makes it hard to spot other, unknown failures, let's get
back to a passing state by pinning the miniconda version that we
download.