### PR TITLE
TST: travis: Set up SSH for localhost

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,10 @@ before_install:
   # The ultimate one-liner setup for NeuroDebian repository
   - bash <(wget -q -O- http://neuro.debian.net/_files/neurodebian-travis.sh)
   - travis_retry sudo apt-get update -qq
+  - if [ ! -z "${REPROMAN_TESTS_SSH:-}" ]; then
+      sudo eatmydata tools/ci/prep-travis-forssh-sudo.sh;
+      tools/ci/prep-travis-forssh.sh;
+    fi
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"
 

--- a/reproman/resource/ssh.py
+++ b/reproman/resource/ssh.py
@@ -80,18 +80,17 @@ class SSH(Resource):
         # See: https://github.com/ReproNim/reproman/commit/3807f1287c39ea2393bae26803e6da8122ac5cff
         from fabric import Connection
         from paramiko import AuthenticationException
-        key_filename = None
+        connect_kwargs = {}
         if self.key_filename:
-            key_filename = [self.key_filename]
+            connect_kwargs["key_filename"] = [self.key_filename]
+        if password:
+            connect_kwargs["password"] = password
 
         self._connection = Connection(
             self.host,
             user=self.user,
             port=self.port,
-            connect_kwargs={
-                'key_filename': key_filename,
-                'password': password
-            }
+            connect_kwargs=connect_kwargs
         )
 
         if self.key_filename:

--- a/tools/ci/prep-travis-forssh-sudo.sh
+++ b/tools/ci/prep-travis-forssh-sudo.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -eu
+
+echo "127.0.0.1  reproman-test" >> /etc/hosts
+apt-get install openssh-client

--- a/tools/ci/prep-travis-forssh.sh
+++ b/tools/ci/prep-travis-forssh.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -eu
+
+mkdir -p ~/.ssh
+echo -e "Host localhost\n\tStrictHostKeyChecking no\n\tIdentityFile /tmp/rman-test-ssh-id\n" >> ~/.ssh/config
+echo -e "Host reproman-test\n\tStrictHostKeyChecking no\n\tIdentityFile /tmp/rman-test-ssh-id\n" >> ~/.ssh/config
+ssh-keygen -f /tmp/rman-test-ssh-id -N ""
+cat /tmp/rman-test-ssh-id.pub >> ~/.ssh/authorized_keys
+eval $(ssh-agent)
+ssh-add /tmp/rman-test-ssh-id
+
+cat ~/.ssh/config
+
+echo "DEBUG: test connection to localhost ..."
+ssh -v localhost exit
+echo "DEBUG: test connection to reproman-test ..."
+ssh -v reproman-test exit


### PR DESCRIPTION
Doing so will allow us to test `run`, in particular the set prepartion
and state management of DataLad datasets over SSH, without needing to
go through a Docker container.

The tools/ci/ scripts are copied from DataLad (6307824f2), with slight
modifications.