### PR TITLE
TST: Adjust ExceptionInfo use for compatiblity with pytest v5.0.0

### DIFF
--- a/reproman/interface/tests/test_run.py
+++ b/reproman/interface/tests/test_run.py
@@ -40,13 +40,13 @@ lgr = logging.getLogger("reproman.interface.tests.test_run")
 def test_run_no_command(command):
     with pytest.raises(ValueError) as exc:
         run(command=command)
-    assert "No command" in str(exc)
+    assert "No command" in str(exc.value)
 
 
 def test_run_no_resource():
     with pytest.raises(ValueError) as exc:
         run(command="blahbert")
-    assert "No resource" in str(exc)
+    assert "No resource" in str(exc.value)
 
 
 @pytest.mark.parametrize("arg,expected",
@@ -226,19 +226,19 @@ def test_run_resource_specification(context):
     with pytest.raises(ResourceNotFoundError) as exc:
         run(command=["doesnt", "matter"],
             job_specs=["js0.yaml"])
-    assert "name-via-js" in str(exc)
+    assert "name-via-js" in str(exc.value)
 
     # If job spec as name and ID, ID takes precedence.
     with pytest.raises(ResourceNotFoundError) as exc:
         run(command=["doesnt", "matter"],
             job_specs=["js1.yaml"])
-    assert "id-via-js" in str(exc)
+    assert "id-via-js" in str(exc.value)
 
     # Command-line overrides job spec.
     with pytest.raises(ResourceNotFoundError) as exc:
         run(command=["doesnt", "matter"], resref="fromcli",
             job_specs=["js1.yaml"])
-    assert "fromcli" in str(exc)
+    assert "fromcli" in str(exc.value)
 
 
 def try_fetch(fetch_fn, ntimes=5):
@@ -398,7 +398,7 @@ def test_jobs_ambig_id_match(context):
 
     with pytest.raises(ValueError) as exc:
         jobs(queries=[jobid0[0], jobid1[0]])
-    assert "matches multiple jobs" in str(exc)
+    assert "matches multiple jobs" in str(exc.value)
 
 
 def test_jobs_deleted_resource(context):

--- a/reproman/resource/tests/test_base.py
+++ b/reproman/resource/tests/test_base.py
@@ -252,10 +252,10 @@ def test_get_resource_class():
     # but it doesn't have a corresponding resource class.
     with pytest.raises(ResourceError) as exc:
         get_resource_class("base")
-    assert "Failed to find" in str(exc)
+    assert "Failed to find" in str(exc.value)
 
     # We recognize when s/_/-/ would give an existing class and provide an
     # informative error.
     with pytest.raises(ResourceError) as exc:
         get_resource_class("docker_container")
-    assert "docker-container" in str(exc)
+    assert "docker-container" in str(exc.value)

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -421,7 +421,7 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
         create_tree(orc1.working_directory, {"dirty": ""})
         with pytest.raises(OrchestratorError) as exc:
             orc1.prepare_remote()
-        assert "dirty" in str(exc)
+        assert "dirty" in str(exc.value)
 
 
 def test_orc_datalad_abort_if_detached(job_spec, dataset, shell):
@@ -457,7 +457,7 @@ def test_head_at_unknown_ref(dataset):
     with pytest.raises(OrchestratorError) as exc:
         with orcs.head_at(dataset, "youdontknowme"):
             pass
-    assert "youdontknowme" in str(exc)
+    assert "youdontknowme" in str(exc.value)
 
 
 def test_head_at_empty_branch(dataset):
@@ -468,7 +468,7 @@ def test_head_at_empty_branch(dataset):
     with pytest.raises(OrchestratorError) as exc:
         with orcs.head_at(dataset, "master"):
             pass
-    assert "No commit" in str(exc)
+    assert "No commit" in str(exc.value)
 
 
 def test_head_at_no_move(dataset):

--- a/reproman/tests/test_interface.py
+++ b/reproman/tests/test_interface.py
@@ -71,7 +71,7 @@ def test_param():
     with pytest.raises(ValueError) as cmr:
         Parameter(unknown_arg=123)
     assert_in('Detected unknown argument(s) for the Parameter: unknown_arg',
-              str(cmr))
+              str(cmr.value))
 
 
 def test_interface():

--- a/reproman/tests/test_skip.py
+++ b/reproman/tests/test_skip.py
@@ -62,4 +62,4 @@ def test_other_attribute_error():
         with pytest.raises(AttributeError) as exc:
             m = Mark()
             m.skipif_no_confusion
-        assert "don't get confused" in str(exc)
+        assert "don't get confused" in str(exc.value)


### PR DESCRIPTION
```
pytest v5.0.0 contains 65c2a8192 (Remove ExceptionInfo.__str__,
falling back to __repr__, 2019-06-06), which leads to calls like
`assert in str(exc)` failing with message like

    AssertionError: assert 'whatever' in '<ExceptionInfo ValueError tblen=2>'

We need to use the .value attribute, as some of our calls already
do.  (Other options would be to use the `match` keyword of
pytest.raises() or to call exc.match()).
```