### PR TITLE
run: Use new ssh setup in tests (v2)

### DIFF
--- a/reproman/support/jobs/job_templates/runscript/datalad-pair-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/datalad-pair-run.template.sh
@@ -3,8 +3,19 @@
 {% block post_command %}
 {{ super() }}
 
+prev_commit=$(git rev-parse HEAD)
+
 {% include "includes/datalad-add.template.sh" %}
 
 {% include "includes/create-ref.template.sh" %}
+
+if test -z "$(git status --untracked-files=normal --ignore-submodules=none --porcelain)"
+then
+    git reset --hard $prev_commit
+else
+    echo "[ReproMan] Remote repository is unexpectedly dirty" >&2
+    git status
+fi
+
 
 {% endblock %}

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -664,7 +664,9 @@ class PrepareRemoteDataladMixin(object):
                     # All right, something looks off.
                     raise exc
             else:
-                failed = list(map(int, failed_ref.strip().split())) or failed
+                # Line format: mode<SP>type<SP>object<TAB>filename
+                failed = [int(ln.split("\t")[1])
+                          for ln in failed_ref.strip().splitlines()]
         return failed
 
     def _assert_clean_repo(self):

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -331,10 +331,6 @@ def test_orc_datalad_pair_run_ontop(job_spec, dataset, shell):
         orc0 = do(js0)
         orc1 = do(js1)
 
-        # Ran on top, so both exist in working tree.
-        assert op.exists(op.join(orc0.meta_directory, "status.0"))
-        assert op.exists(op.join(orc1.meta_directory, "status.0"))
-
         ref0 = "refs/reproman/{}".format(orc0.jobid)
         ref1 = "refs/reproman/{}".format(orc1.jobid)
 

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -261,7 +261,7 @@ def test_orc_datalad_run_failed(job_spec, dataset, ssh):
 
 
 @pytest.mark.integration
-def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
+def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, ssh):
     # Start two orchestrators from the same point:
     #
     #   orc 0, master
@@ -274,7 +274,7 @@ def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
     js1 = dict(job_spec, command_str='bash -c "echo other >other"')
     with chpwd(ds.path):
         orc0, orc1 = [
-            orcs.DataladPairRunOrchestrator(shell, submission_type="local",
+            orcs.DataladPairRunOrchestrator(ssh, submission_type="local",
                                             job_spec=js)
             for js in [js0, js1]]
 
@@ -304,7 +304,7 @@ def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
 
 
 @pytest.mark.integration
-def test_orc_datalad_pair_run_ontop(job_spec, dataset, shell):
+def test_orc_datalad_pair_run_ontop(job_spec, dataset, ssh):
     # Run one orchestrator and fetch, then run another and fetch:
     #
     #   orc 1, master
@@ -321,7 +321,7 @@ def test_orc_datalad_pair_run_ontop(job_spec, dataset, shell):
     with chpwd(ds.path):
         def do(js):
             orc = orcs.DataladPairRunOrchestrator(
-                shell, submission_type="local", job_spec=js)
+                ssh, submission_type="local", job_spec=js)
             orc.prepare_remote()
             orc.submit()
             orc.follow()
@@ -399,10 +399,10 @@ def test_orc_datalad_pair(job_spec, dataset, shell):
 
 
 @pytest.mark.integration
-def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
+def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
     def get_orc():
         return orcs.DataladPairOrchestrator(
-            shell, submission_type="local", job_spec=job_spec)
+            ssh, submission_type="local", job_spec=job_spec)
 
     with chpwd(dataset.path):
         orc0 = get_orc()
@@ -513,7 +513,7 @@ def test_dataset_as_dict(shell, dataset, job_spec):
                          ["local",
                           pytest.param("condor", marks=mark.skipif_no_condor)],
                          ids=["sub:local", "sub:condor"])
-def test_orc_datalad_concurrent(job_spec, dataset, shell, orc_class, sub_type):
+def test_orc_datalad_concurrent(job_spec, dataset, ssh, orc_class, sub_type):
     names = ["paul", "rosa"]
 
     job_spec["inputs"] = ["{p[name]}.in"]
@@ -528,7 +528,7 @@ def test_orc_datalad_concurrent(job_spec, dataset, shell, orc_class, sub_type):
     dataset.save(path=in_files)
 
     with chpwd(dataset.path):
-        orc = orc_class(shell, submission_type=sub_type, job_spec=job_spec)
+        orc = orc_class(ssh, submission_type=sub_type, job_spec=job_spec)
         orc.prepare_remote()
         orc.submit()
         orc.follow()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -244,13 +244,13 @@ def test_orc_plain_failure(tmpdir, job_spec, shell):
 
 
 @pytest.mark.integration
-def test_orc_datalad_run_failed(job_spec, dataset, shell):
+def test_orc_datalad_run_failed(job_spec, dataset, ssh):
     job_spec["command_str"] = "iwillfail"
     job_spec["inputs"] = []
 
     with chpwd(dataset.path):
-        orc = orcs.DataladLocalRunOrchestrator(
-            shell, submission_type="local", job_spec=job_spec)
+        orc = orcs.DataladPairRunOrchestrator(
+            ssh, submission_type="local", job_spec=job_spec)
         orc.prepare_remote()
         orc.submit()
         orc.follow()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -46,6 +46,13 @@ def shell():
     return Shell("localshell")
 
 
+@pytest.fixture(scope="module")
+def ssh():
+    skipif.no_ssh()
+    from reproman.resource.ssh import SSH
+    return SSH("testssh", host="reproman-test")
+
+
 def test_orc_root_directory(shell):
     orc = orcs.PlainOrchestrator(shell, submission_type="local")
     assert orc.root_directory == op.expanduser("~/.reproman/run-root")

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -400,17 +400,19 @@ def test_orc_datalad_pair(job_spec, dataset, shell):
 
 @pytest.mark.integration
 def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
-    with chpwd(dataset.path):
-        orc0 = orcs.DataladPairOrchestrator(
+    def get_orc():
+        return orcs.DataladPairOrchestrator(
             shell, submission_type="local", job_spec=job_spec)
+
+    with chpwd(dataset.path):
+        orc0 = get_orc()
         # Run one job so that we create the remote repository.
         orc0.prepare_remote()
         orc0.submit()
         orc0.follow()
 
     with chpwd(dataset.path):
-        orc1 = orcs.DataladPairOrchestrator(
-            shell, submission_type="local", job_spec=job_spec)
+        orc1 = get_orc()
         create_tree(orc1.working_directory, {"dirty": ""})
         with pytest.raises(OrchestratorError) as exc:
             orc1.prepare_remote()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -113,6 +113,11 @@ def test_orc_plain_docker(check_orc_plain, docker_resource, job_spec):
     check_orc_plain(docker_resource, job_spec)
 
 
+@pytest.mark.integration
+def test_orc_plain_ssh(check_orc_plain, ssh, job_spec):
+    check_orc_plain(ssh, job_spec)
+
+
 @pytest.mark.skipif(external_versions["datalad"], reason="DataLad found")
 def test_orc_no_datalad(tmpdir, shell):
     with chpwd(str(tmpdir)):

--- a/tools/ci/install_datalad
+++ b/tools/ci/install_datalad
@@ -3,5 +3,9 @@
 set -eu
 
 sudo apt-get install git-annex-standalone
+
+# Install datalad system-wide for use with localhost ssh
+sudo apt-get install datalad
+# ... and install it into the virtualenv.
 pip install git+https://github.com/datalad/datalad.git
 pip install datalad-container


### PR DESCRIPTION
This is the first topic split from gh-452:

> * adjusting more tests to use SSH resource rather than a local shell resource.  This is important because much of prepare_remote() goes through a different code path if we use the local shell.

The runs in gh-452 failed with a Git protocol error.  That should be fixed with datalad/datalad#3616.  ~I haven't yet merged that into datalad's master branch because its Travis tests are currently pretty busy.  For now I'm putting a temporary commit at the tip of this PR so that we pull in that fix from a throw-away branch~ (edit: it's now in DataLad's master).

<details>
<summary>range-diff with gh-452</summary>

```
 1:  9f9e34663 <  -:  --------- ENH: run: Abort if dataset is dirty
 2:  94924225b <  -:  --------- STY: orchestrators: Convert string command to list
 3:  ec45f6144 <  -:  --------- BF: orchestrators: Guard dirty check against Git configuration
 5:  07c8343df !  1:  f27f3198a TST: orchestrators: Add check_orc_plain for SSH resource
    @@ Metadata
     Author: Kyle Meyer <kyle@kyleam.com>
     
      ## Commit message ##
    -    TST: orchestrators: Add check_orc_plain for SSH resource
    +    TST: orchestrators: Add ssh fixture
     
    -    We call this on a local and Docker resource.  Add a call for an SSH
    -    resource because we have a reproman-test host on Travis as of
    -    c4c710b7d (TST: travis: Set up SSH for localhost, 2019-08-08).
    +    We have a reproman-test host on Travis as of c4c710b7d (TST: travis:
    +    Set up SSH for localhost, 2019-08-08).  We should switch most of our
    +    orchestrator tests that use the local shell resource fixture over to
    +    the ssh one because the local shell has a different code path for
    +    prepare_remote() and fetch() because `datalad create-sibling` doesn't
    +    currently support local paths.
     
         Note that for now we just skip the test if REPROMAN_TESTS_SSH is
         unset, but we might want to be more specific because there are other
    @@ reproman/support/jobs/tests/test_orchestrators.py: def shell():
      def test_orc_root_directory(shell):
          orc = orcs.PlainOrchestrator(shell, submission_type="local")
          assert orc.root_directory == op.expanduser("~/.reproman/run-root")
    -@@ reproman/support/jobs/tests/test_orchestrators.py: def test_orc_plain_docker(check_orc_plain, docker_resource, job_spec):
    -     check_orc_plain(docker_resource, job_spec)
    - 
    - 
    -+@pytest.mark.integration
    -+def test_orc_plain_ssh(check_orc_plain, ssh, job_spec):
    -+    check_orc_plain(ssh, job_spec)
    -+
    -+
    - @pytest.mark.skipif(external_versions["datalad"], reason="DataLad found")
    - def test_orc_no_datalad(tmpdir, shell):
    -     with chpwd(str(tmpdir)):
 -:  --------- >  2:  d0b4cfb48 TST: orchestrators: Add check_orc_plain for SSH resource
 6:  06c28732b =  3:  5b4b3b982 TST: orchestrators: Drop module-scoped dataset fixture
 7:  9990c46cc !  4:  0e8428db0 BF: orchestrators: Fix parsing status from ls-tree output
    @@ reproman/support/jobs/orchestrators.py: def failed_subjobs(self):
                          raise exc
                  else:
     -                failed = list(map(int, failed_ref.strip().split())) or failed
    -+                # Line format: mode type object filename
    -+                failed = [int(ln.split()[3])
    ++                # Line format: mode<SP>type<SP>object<TAB>filename
    ++                failed = [int(ln.split("\t")[1])
     +                          for ln in failed_ref.strip().splitlines()]
              return failed
      
 8:  2cbeda75f =  5:  e728a6fd8 ENH: datalad-pair-run orchestrator: Reset to original commit
 4:  1fc411f87 !  6:  b1f34ac56 TST: orchestrators: Move repeated instance creation to a helper
    @@ reproman/support/jobs/tests/test_orchestrators.py: def test_orc_datalad_pair(job
      
      @pytest.mark.integration
      def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
    +-    with chpwd(dataset.path):
    +-        orc0 = orcs.DataladPairOrchestrator(
     +    def get_orc():
     +        return orcs.DataladPairOrchestrator(
    -+            shell, submission_type="local", job_spec=job_spec)
    +             shell, submission_type="local", job_spec=job_spec)
     +
    -     with chpwd(dataset.path):
    -         # We abort if the local dataset is dirty.
    -         create_tree(dataset.path, {"local-dirt": ""})
    -         with pytest.raises(OrchestratorError) as exc:
    --            orcs.DataladPairOrchestrator(
    --                shell, submission_type="local", job_spec=job_spec)
    -+            get_orc()
    -         assert "dirty" in str(exc.value)
    -         os.unlink("local-dirt")
    - 
    --        orc0 = orcs.DataladPairOrchestrator(
    --            shell, submission_type="local", job_spec=job_spec)
    ++    with chpwd(dataset.path):
     +        orc0 = get_orc()
              # Run one job so that we create the remote repository.
              orc0.prepare_remote()
 9:  fdfda0567 !  7:  72ff729c2 TST: orchestrators: Switch more tests over to SSH resource
    @@ reproman/support/jobs/tests/test_orchestrators.py: def test_orc_datalad_pair(job
     +            ssh, submission_type="local", job_spec=job_spec)
      
          with chpwd(dataset.path):
    -         # We abort if the local dataset is dirty.
    +         orc0 = get_orc()
     @@ reproman/support/jobs/tests/test_orchestrators.py: def test_dataset_as_dict(shell, dataset, job_spec):
                               ["local",
                                pytest.param("condor", marks=mark.skipif_no_condor)],
10:  e0de142d9 <  -:  --------- ENH: orchestrators: Add directory parameter to _assert_clean_repo()
11:  dda27fb53 <  -:  --------- BF: orchestrators: Make dirty check work better with subdatasets
```

</details>
