### PR TITLE
run: Improve dirty checks

### DIFF
--- a/reproman/support/jobs/job_templates/runscript/datalad-pair-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/datalad-pair-run.template.sh
@@ -3,8 +3,19 @@
 {% block post_command %}
 {{ super() }}
 
+prev_commit=$(git rev-parse HEAD)
+
 {% include "includes/datalad-add.template.sh" %}
 
 {% include "includes/create-ref.template.sh" %}
+
+if test -z "$(git status --untracked-files=normal --ignore-submodules=none --porcelain)"
+then
+    git reset --hard $prev_commit
+else
+    echo "[ReproMan] Remote repository is unexpectedly dirty" >&2
+    git status
+fi
+
 
 {% endblock %}

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -674,7 +674,8 @@ class PrepareRemoteDataladMixin(object):
         return failed
 
     def _assert_clean_repo(self):
-        if self._execute_in_wdir("git status --porcelain"):
+        cmd = ["git", "status", "--porcelain"]
+        if self._execute_in_wdir(cmd):
             raise OrchestratorError("Remote repository {} is dirty"
                                     .format(self.working_directory))
 

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -664,7 +664,9 @@ class PrepareRemoteDataladMixin(object):
                     # All right, something looks off.
                     raise exc
             else:
-                failed = list(map(int, failed_ref.strip().split())) or failed
+                # Line format: mode<SP>type<SP>object<TAB>filename
+                failed = [int(ln.split("\t")[1])
+                          for ln in failed_ref.strip().splitlines()]
         return failed
 
     def _assert_clean_repo(self):

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -673,12 +673,14 @@ class PrepareRemoteDataladMixin(object):
                           for ln in failed_ref.strip().splitlines()]
         return failed
 
-    def _assert_clean_repo(self):
+    def _assert_clean_repo(self, cwd=None):
         cmd = ["git", "status", "--porcelain",
                "--ignore-submodules=none", "--untracked-files=normal"]
-        if self._execute_in_wdir(cmd):
+        out, _ = self.session.execute_command(
+            cmd, cwd=cwd or self.working_directory)
+        if out:
             raise OrchestratorError("Remote repository {} is dirty"
-                                    .format(self.working_directory))
+                                    .format(cwd or self.working_directory))
 
     def _checkout_target(self):
         self._assert_clean_repo()

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -674,7 +674,8 @@ class PrepareRemoteDataladMixin(object):
         return failed
 
     def _assert_clean_repo(self):
-        cmd = ["git", "status", "--porcelain"]
+        cmd = ["git", "status", "--porcelain",
+               "--ignore-submodules=none", "--untracked-files=normal"]
         if self._execute_in_wdir(cmd):
             raise OrchestratorError("Remote repository {} is dirty"
                                     .format(self.working_directory))

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -484,6 +484,10 @@ class DataladOrchestrator(Orchestrator, metaclass=abc.ABCMeta):
         if self._resurrection:
             self.head = self.job_spec.get("head")
         else:
+            if self.ds.repo.dirty:
+                raise OrchestratorError("Local dataset {} is dirty. "
+                                        "Save or discard uncommitted changes"
+                                        .format(self.ds.path))
             self._configure_repo()
             self.head = self.ds.repo.get_hexsha()
             _datalad_check_container(self.ds, self.job_spec)

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -675,7 +675,7 @@ class PrepareRemoteDataladMixin(object):
 
     def _assert_clean_repo(self, cwd=None):
         cmd = ["git", "status", "--porcelain",
-               "--ignore-submodules=none", "--untracked-files=normal"]
+               "--ignore-submodules=all", "--untracked-files=normal"]
         out, _ = self.session.execute_command(
             cmd, cwd=cwd or self.working_directory)
         if out:
@@ -718,13 +718,15 @@ class PrepareRemoteDataladMixin(object):
         self._execute_in_wdir(["git", "annex", "init"])
         for res in self._execute_datalad_json_command(
                 ["subdatasets", "--fulfilled=true", "--recursive"]):
-            lgr.debug("Adjusting state of %s", res["path"])
+            cwd = res["path"]
+            self._assert_clean_repo(cwd=cwd)
+            lgr.debug("Adjusting state of %s", cwd)
             cmds = [["git", "checkout", res["revision"]],
                     ["git", "annex", "init"]]
             for cmd in cmds:
                 try:
                     out, _ = self.session.execute_command(
-                        cmd, cwd=res["path"])
+                        cmd, cwd=cwd)
                 except CommandError as exc:
                     raise OrchestratorError(str(exc))
 

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -331,10 +331,6 @@ def test_orc_datalad_pair_run_ontop(job_spec, dataset, shell):
         orc0 = do(js0)
         orc1 = do(js1)
 
-        # Ran on top, so both exist in working tree.
-        assert op.exists(op.join(orc0.meta_directory, "status.0"))
-        assert op.exists(op.join(orc1.meta_directory, "status.0"))
-
         ref0 = "refs/reproman/{}".format(orc0.jobid)
         ref1 = "refs/reproman/{}".format(orc1.jobid)
 

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -405,6 +405,13 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
             ssh, submission_type="local", job_spec=job_spec)
 
     with chpwd(dataset.path):
+        # We abort if the local dataset is dirty.
+        create_tree(dataset.path, {"local-dirt": ""})
+        with pytest.raises(OrchestratorError) as exc:
+            get_orc()
+        assert "dirty" in str(exc.value)
+        os.unlink("local-dirt")
+
         orc0 = get_orc()
         # Run one job so that we create the remote repository.
         orc0.prepare_remote()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -261,7 +261,7 @@ def test_orc_datalad_run_failed(job_spec, dataset, ssh):
 
 
 @pytest.mark.integration
-def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
+def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, ssh):
     # Start two orchestrators from the same point:
     #
     #   orc 0, master
@@ -274,7 +274,7 @@ def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
     js1 = dict(job_spec, command_str='bash -c "echo other >other"')
     with chpwd(ds.path):
         orc0, orc1 = [
-            orcs.DataladPairRunOrchestrator(shell, submission_type="local",
+            orcs.DataladPairRunOrchestrator(ssh, submission_type="local",
                                             job_spec=js)
             for js in [js0, js1]]
 
@@ -304,7 +304,7 @@ def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, shell):
 
 
 @pytest.mark.integration
-def test_orc_datalad_pair_run_ontop(job_spec, dataset, shell):
+def test_orc_datalad_pair_run_ontop(job_spec, dataset, ssh):
     # Run one orchestrator and fetch, then run another and fetch:
     #
     #   orc 1, master
@@ -321,7 +321,7 @@ def test_orc_datalad_pair_run_ontop(job_spec, dataset, shell):
     with chpwd(ds.path):
         def do(js):
             orc = orcs.DataladPairRunOrchestrator(
-                shell, submission_type="local", job_spec=js)
+                ssh, submission_type="local", job_spec=js)
             orc.prepare_remote()
             orc.submit()
             orc.follow()
@@ -399,10 +399,10 @@ def test_orc_datalad_pair(job_spec, dataset, shell):
 
 
 @pytest.mark.integration
-def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
+def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
     def get_orc():
         return orcs.DataladPairOrchestrator(
-            shell, submission_type="local", job_spec=job_spec)
+            ssh, submission_type="local", job_spec=job_spec)
 
     with chpwd(dataset.path):
         orc0 = get_orc()
@@ -513,7 +513,7 @@ def test_dataset_as_dict(shell, dataset, job_spec):
                          ["local",
                           pytest.param("condor", marks=mark.skipif_no_condor)],
                          ids=["sub:local", "sub:condor"])
-def test_orc_datalad_concurrent(job_spec, dataset, shell, orc_class, sub_type):
+def test_orc_datalad_concurrent(job_spec, dataset, ssh, orc_class, sub_type):
     names = ["paul", "rosa"]
 
     job_spec["inputs"] = ["{p[name]}.in"]
@@ -528,7 +528,7 @@ def test_orc_datalad_concurrent(job_spec, dataset, shell, orc_class, sub_type):
     dataset.save(path=in_files)
 
     with chpwd(dataset.path):
-        orc = orc_class(shell, submission_type=sub_type, job_spec=job_spec)
+        orc = orc_class(ssh, submission_type=sub_type, job_spec=job_spec)
         orc.prepare_remote()
         orc.submit()
         orc.follow()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -244,13 +244,13 @@ def test_orc_plain_failure(tmpdir, job_spec, shell):
 
 
 @pytest.mark.integration
-def test_orc_datalad_run_failed(job_spec, dataset, shell):
+def test_orc_datalad_run_failed(job_spec, dataset, ssh):
     job_spec["command_str"] = "iwillfail"
     job_spec["inputs"] = []
 
     with chpwd(dataset.path):
-        orc = orcs.DataladLocalRunOrchestrator(
-            shell, submission_type="local", job_spec=job_spec)
+        orc = orcs.DataladPairRunOrchestrator(
+            ssh, submission_type="local", job_spec=job_spec)
         orc.prepare_remote()
         orc.submit()
         orc.follow()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -46,6 +46,13 @@ def shell():
     return Shell("localshell")
 
 
+@pytest.fixture(scope="module")
+def ssh():
+    skipif.no_ssh()
+    from reproman.resource.ssh import SSH
+    return SSH("testssh", host="reproman-test")
+
+
 def test_orc_root_directory(shell):
     orc = orcs.PlainOrchestrator(shell, submission_type="local")
     assert orc.root_directory == op.expanduser("~/.reproman/run-root")

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -400,17 +400,19 @@ def test_orc_datalad_pair(job_spec, dataset, shell):
 
 @pytest.mark.integration
 def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
-    with chpwd(dataset.path):
-        orc0 = orcs.DataladPairOrchestrator(
+    def get_orc():
+        return orcs.DataladPairOrchestrator(
             shell, submission_type="local", job_spec=job_spec)
+
+    with chpwd(dataset.path):
+        orc0 = get_orc()
         # Run one job so that we create the remote repository.
         orc0.prepare_remote()
         orc0.submit()
         orc0.follow()
 
     with chpwd(dataset.path):
-        orc1 = orcs.DataladPairOrchestrator(
-            shell, submission_type="local", job_spec=job_spec)
+        orc1 = get_orc()
         create_tree(orc1.working_directory, {"dirty": ""})
         with pytest.raises(OrchestratorError) as exc:
             orc1.prepare_remote()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -113,6 +113,11 @@ def test_orc_plain_docker(check_orc_plain, docker_resource, job_spec):
     check_orc_plain(docker_resource, job_spec)
 
 
+@pytest.mark.integration
+def test_orc_plain_ssh(check_orc_plain, ssh, job_spec):
+    check_orc_plain(ssh, job_spec)
+
+
 @pytest.mark.skipif(external_versions["datalad"], reason="DataLad found")
 def test_orc_no_datalad(tmpdir, shell):
     with chpwd(str(tmpdir)):

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -400,9 +400,28 @@ def test_orc_datalad_pair(job_spec, dataset, shell):
 
 @pytest.mark.integration
 def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
-    def get_orc():
-        return orcs.DataladPairOrchestrator(
-            ssh, submission_type="local", job_spec=job_spec)
+    subds = dataset.create(path="sub")
+    subds.create(path="subsub")
+    dataset.save()
+
+    job_spec["inputs"] = []
+    job_spec["outputs"] = []
+
+    def get_orc(jspec=None):
+        return orcs.DataladPairRunOrchestrator(
+            ssh, submission_type="local",
+            job_spec=jspec or job_spec)
+
+    def run(**spec_kwds):
+        jspec = dict(job_spec, **spec_kwds)
+        with chpwd(dataset.path):
+            orc = get_orc(jspec)
+            # Run one job so that we create the remote repository.
+            orc.prepare_remote()
+            orc.submit()
+            orc.follow()
+            orc.fetch()
+            return orc
 
     with chpwd(dataset.path):
         # We abort if the local dataset is dirty.
@@ -412,11 +431,8 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
         assert "dirty" in str(exc.value)
         os.unlink("local-dirt")
 
-        orc0 = get_orc()
-        # Run one job so that we create the remote repository.
-        orc0.prepare_remote()
-        orc0.submit()
-        orc0.follow()
+    # Run one job so that we create the remote repository.
+    run(command_str="echo one >one")
 
     with chpwd(dataset.path):
         orc1 = get_orc()
@@ -424,6 +440,25 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
         with pytest.raises(OrchestratorError) as exc:
             orc1.prepare_remote()
         assert "dirty" in str(exc.value)
+    os.unlink(op.join(orc1.working_directory, "dirty"))
+
+    # We can run if the submodule simply has a different commit checked out.
+    run(command_str="echo two >two")
+
+    create_tree(op.join(dataset.path, "sub"), {"for-local-commit": ""})
+    dataset.add(".", recursive=True)
+
+    run(command_str="echo three >three")
+
+    # But we abort if subdataset is actually dirty.
+    with chpwd(dataset.path):
+        orc2 = get_orc()
+        create_tree(orc2.working_directory,
+                    {"sub": {"subsub": {"subdirt": ""}}})
+        with pytest.raises(OrchestratorError) as exc:
+            orc2.prepare_remote()
+        assert "dirty" in str(exc.value)
+    os.unlink(op.join(orc2.working_directory, "sub", "subsub", "subdirt"))
 
 
 def test_orc_datalad_abort_if_detached(job_spec, dataset, shell):

--- a/tools/ci/install_datalad
+++ b/tools/ci/install_datalad
@@ -3,5 +3,9 @@
 set -eu
 
 sudo apt-get install git-annex-standalone
+
+# Install datalad system-wide for use with localhost ssh
+sudo apt-get install datalad
+# ... and install it into the virtualenv.
 pip install git+https://github.com/datalad/datalad.git
 pip install datalad-container


### PR DESCRIPTION
This is the second topic split from gh-452:

> * improving the dirty checks, particularly when there are subdatasets.

This relies on (and is on top of) gh-453.  Here's the [restricted comparison][0].

[0]: https://github.com/repronim/reproman/compare/kyleam:run-more-ssh...kyleam:run-more-dirt

<details>
<summary>range-diff with gh-452</summary>

```
 1:  9f9e34663 !  1:  84981a784 ENH: run: Abort if dataset is dirty
    @@ reproman/support/jobs/orchestrators.py: def __init__(self, resource, submission_
                  _datalad_check_container(self.ds, self.job_spec)
     
      ## reproman/support/jobs/tests/test_orchestrators.py ##
    -@@ reproman/support/jobs/tests/test_orchestrators.py: def test_orc_datalad_pair(job_spec, dataset, shell):
    - @pytest.mark.integration
    - def test_orc_datalad_abort_if_dirty(job_spec, dataset, shell):
    +@@ reproman/support/jobs/tests/test_orchestrators.py: def get_orc():
    +             ssh, submission_type="local", job_spec=job_spec)
    + 
          with chpwd(dataset.path):
     +        # We abort if the local dataset is dirty.
     +        create_tree(dataset.path, {"local-dirt": ""})
     +        with pytest.raises(OrchestratorError) as exc:
    -+            orcs.DataladPairOrchestrator(
    -+                shell, submission_type="local", job_spec=job_spec)
    ++            get_orc()
     +        assert "dirty" in str(exc.value)
     +        os.unlink("local-dirt")
     +
    -         orc0 = orcs.DataladPairOrchestrator(
    -             shell, submission_type="local", job_spec=job_spec)
    +         orc0 = get_orc()
              # Run one job so that we create the remote repository.
    +         orc0.prepare_remote()
 2:  94924225b =  2:  819a88edf STY: orchestrators: Convert string command to list
 3:  ec45f6144 =  3:  74af7653f BF: orchestrators: Guard dirty check against Git configuration
 4:  1fc411f87 <  -:  --------- TST: orchestrators: Move repeated instance creation to a helper
 5:  07c8343df <  -:  --------- TST: orchestrators: Add check_orc_plain for SSH resource
 6:  06c28732b <  -:  --------- TST: orchestrators: Drop module-scoped dataset fixture
 7:  9990c46cc <  -:  --------- BF: orchestrators: Fix parsing status from ls-tree output
 8:  2cbeda75f <  -:  --------- ENH: datalad-pair-run orchestrator: Reset to original commit
 9:  fdfda0567 <  -:  --------- TST: orchestrators: Switch more tests over to SSH resource
10:  e0de142d9 =  4:  a332e48d1 ENH: orchestrators: Add directory parameter to _assert_clean_repo()
11:  dda27fb53 =  5:  a61029d5e BF: orchestrators: Make dirty check work better with subdatasets
```

</details>
