### PR TITLE
run: Dump job spec in meta_directory

### DIFF
--- a/reproman/interface/jobs.py
+++ b/reproman/interface/jobs.py
@@ -99,7 +99,7 @@ def show_oneline(job, status=False):
             ", " + queried_status if queried_status else "")
     else:
         stat = ""
-    cmd = job["command_str"]
+    cmd = job["_resolved_command_str"]
     print(fmt
           .format(status=stat, j=job,
                   cmd=cmd[:47] + "..." if len(cmd) > 50 else cmd))

--- a/reproman/interface/jobs.py
+++ b/reproman/interface/jobs.py
@@ -76,7 +76,7 @@ def _resurrect_orc(job):
         orchestrator_class = ORCHESTRATORS[job["orchestrator"]]
         orc = orchestrator_class(resource, job["submitter"], job,
                                  resurrection=True)
-        orc.submitter.submission_id = job.get("submission_id")
+        orc.submitter.submission_id = job.get("_submission_id")
     return orc
 
 
@@ -86,7 +86,7 @@ def _resurrect_orc(job):
 def show_oneline(job, status=False):
     """Display `job` as a single summary line.
     """
-    fmt = "{status}{j[jobid]} on {j[resource_name]} via {j[submitter]}$ {cmd}"
+    fmt = "{status}{j[_jobid]} on {j[resource_name]} via {j[submitter]}$ {cmd}"
     if status:
         orc = _resurrect_orc(job)
         orc_status = orc.status
@@ -126,7 +126,7 @@ def fetch(job):
         LREG.unregister(orc.jobid)
     else:
         lgr.warning("Not fetching incomplete job %s [status: %s]",
-                    job["jobid"],
+                    job["_jobid"],
                     orc.status or "unknown")
 
 

--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -363,7 +363,7 @@ class Run(Interface):
         spec = _combine_job_specs(_load_specs(job_specs or []) +
                                   [job_parameters, cli_spec])
 
-        spec["batch_parameters"] = _resolve_batch_parameters(
+        spec["_resolved_batch_parameters"] = _resolve_batch_parameters(
             spec.get("batch_spec"), spec.get("batch_parameters"))
 
         # Treat "command" as a special case because it's a list and the

--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -369,15 +369,14 @@ class Run(Interface):
         # Treat "command" as a special case because it's a list and the
         # template expects a string.
         if not command and "command_str" in spec:
-            pass
+            spec["_resolved_command_str"] = spec["command_str"]
         elif not command and "command" not in spec:
             raise ValueError("No command specified via CLI or job spec")
         else:
             command = command or spec["command"]
             # Unlike datalad run, we're only accepting a list form for now.
-            command_str = " ".join(map(shlex_quote, command))
             spec["command"] = command
-            spec["command_str"] = command_str
+            spec["_resolved_command_str"] = " ".join(map(shlex_quote, command))
 
         if resref is None:
             if "resource_id" in spec:

--- a/reproman/support/jobs/job_templates/runscript/base.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/base.template.sh
@@ -4,11 +4,11 @@
 
 set -eu
 
-jobid={{ jobid }}
+jobid={{ _jobid }}
 subjob=$1
-num_subjobs={{ num_subjobs }}
+num_subjobs={{ _num_subjobs }}
 
-metadir={{ shlex_quote(meta_directory) }}
+metadir={{ shlex_quote(_meta_directory) }}
 rootdir={{ shlex_quote(root_directory) }}
 workdir={{ shlex_quote(working_directory) }}
 

--- a/reproman/support/jobs/job_templates/submission/condor.template
+++ b/reproman/support/jobs/job_templates/submission/condor.template
@@ -3,12 +3,12 @@
 #}
 
 Universe     = vanilla
-Executable   = {{ meta_directory }}/runscript
+Executable   = {{ _meta_directory }}/runscript
 environment  = ""
 
-Output  = {{ meta_directory }}/stdout.$(Process)
-Error   = {{ meta_directory }}/stderr.$(Process)
-Log     = {{ meta_directory }}/log.$(Process)
+Output  = {{ _meta_directory }}/stdout.$(Process)
+Error   = {{ _meta_directory }}/stderr.$(Process)
+Log     = {{ _meta_directory }}/log.$(Process)
 
 {#
   TODO: Need to check spec form compatibility between different batch
@@ -25,4 +25,4 @@ request_cpus = {{ num_processes }}
 
 getenv = True
 arguments = "$(Process)"
-queue {{ num_subjobs }}
+queue {{ _num_subjobs }}

--- a/reproman/support/jobs/job_templates/submission/local.template
+++ b/reproman/support/jobs/job_templates/submission/local.template
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -eu
 
-metadir={{ shlex_quote(meta_directory) }}
-num_subjobs={{ num_subjobs }}
+metadir={{ shlex_quote(_meta_directory) }}
+num_subjobs={{ _num_subjobs }}
 
 if test $num_subjobs -eq 1
 then
@@ -16,7 +16,7 @@ else
 
     # Use relative path to meta directory because that doesn't need any special
     # quoting, and the parallel call below wouldn't handle quoting properly.
-    metadir_rel={{ shlex_quote(meta_directory_rel) }}
+    metadir_rel={{ shlex_quote(_meta_directory_rel) }}
     workdir={{ shlex_quote(working_directory) }}
 
     cd "$workdir"

--- a/reproman/support/jobs/job_templates/submission/pbs.template
+++ b/reproman/support/jobs/job_templates/submission/pbs.template
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-#PBS -o {{ shlex_quote(meta_directory) }}/stdout
-#PBS -e {{ shlex_quote(meta_directory) }}/stderr
+#PBS -o {{ shlex_quote(_meta_directory) }}/stdout
+#PBS -e {{ shlex_quote(_meta_directory) }}/stderr
 {% if walltime is defined %}
 #PBS -l walltime={{ walltime }}
 {% endif %}
@@ -11,10 +11,10 @@
 {% if num_nodes is defined or num_processes is defined %}
 #PBS -l nodes={{ num_nodes|default(1, true) }}:ppn={{ num_processes|default(1, true) }}
 {% endif %}
-{% if num_subjobs == 1 %}
+{% if _num_subjobs == 1 %}
 #PBS -t 0
 {% else %}
-#PBS -t 0-{{ num_subjobs - 1}}
+#PBS -t 0-{{ _num_subjobs - 1}}
 {% endif %}
 
-{{ shlex_quote(meta_directory) }}/runscript ${PBS_ARRAYID}
+{{ shlex_quote(_meta_directory) }}/runscript ${PBS_ARRAYID}

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -29,6 +29,7 @@ import os.path as op
 import uuid
 from tempfile import NamedTemporaryFile
 import time
+import yaml
 
 from shlex import quote as shlex_quote
 
@@ -250,6 +251,10 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
         self._put_text(
             "\0".join(self.job_spec["command_array"]),
             op.join(self.meta_directory, "command-array"))
+
+        self._put_text(
+            yaml.safe_dump(self.as_dict()),
+            op.join(self.meta_directory, "spec.yaml"))
 
         subm_id = self.submitter.submit(
             submission_file,

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -171,7 +171,8 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
                    "orchestrator": self.name,
                    "submitter": self.submitter.name,
                    "submission_id": self.submitter.submission_id}
-        return dict(to_dump, **(self.template.kwds if self.template else {}))
+        return dict(self.template.kwds if self.template else {},
+                    **to_dump)
 
     def _prepare_spec(self):
         """Prepare the spec for the run.

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -184,7 +184,7 @@ class Orchestrator(object, metaclass=abc.ABCMeta):
         from reproman.support.globbedpaths import GlobbedPaths
 
         spec = self.job_spec
-        if spec.get("batch_parameters"):
+        if spec.get("_resolved_batch_parameters"):
             raise OrchestratorError(
                 "Batch parameters are currently only supported "
                 "in DataLad orchestrators")
@@ -448,7 +448,7 @@ def _datalad_format_command(ds, spec):
     # DataLad's to avoid potential discrepancies with datalad-run's behavior.
     from datalad.interface.run import GlobbedPaths
 
-    batch_parameters = spec.get("batch_parameters") or [{}]
+    batch_parameters = spec.get("_resolved_batch_parameters") or [{}]
     spec["command_array"] = []
     spec["inputs_array"] = []
     spec["outputs_array"] = []

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -72,7 +72,7 @@ def job_spec(tmpdir):
     return {"root_directory": op.join(str(tmpdir), "nm-run"),
             "inputs": [op.join("d", "in")],
             "outputs": ["out"],
-            "command_str": 'bash -c "cat d/in >out && echo more >>out"'}
+            "_resolved_command_str": 'bash -c "cat d/in >out && echo more >>out"'}
 
 
 @pytest.fixture()
@@ -230,7 +230,7 @@ def test_orc_log_failed(failed):
 
 @pytest.mark.integration
 def test_orc_plain_failure(tmpdir, job_spec, shell):
-    job_spec["command_str"] = "iwillfail"
+    job_spec["_resolved_command_str"] = "iwillfail"
     job_spec["inputs"] = []
     local_dir = str(tmpdir)
     with chpwd(local_dir):
@@ -245,7 +245,7 @@ def test_orc_plain_failure(tmpdir, job_spec, shell):
 
 @pytest.mark.integration
 def test_orc_datalad_run_failed(job_spec, dataset, ssh):
-    job_spec["command_str"] = "iwillfail"
+    job_spec["_resolved_command_str"] = "iwillfail"
     job_spec["inputs"] = []
 
     with chpwd(dataset.path):
@@ -271,7 +271,7 @@ def test_orc_datalad_pair_run_multiple_same_point(job_spec, dataset, ssh):
     #   o
     ds = dataset
     js0 = job_spec
-    js1 = dict(job_spec, command_str='bash -c "echo other >other"')
+    js1 = dict(job_spec, _resolved_command_str='bash -c "echo other >other"')
     with chpwd(ds.path):
         orc0, orc1 = [
             orcs.DataladPairRunOrchestrator(ssh, submission_type="local",
@@ -317,7 +317,7 @@ def test_orc_datalad_pair_run_ontop(job_spec, dataset, ssh):
     ds.add(".")
 
     js0 = job_spec
-    js1 = dict(job_spec, command_str='bash -c "echo other >other"')
+    js1 = dict(job_spec, _resolved_command_str='bash -c "echo other >other"')
     with chpwd(ds.path):
         def do(js):
             orc = orcs.DataladPairRunOrchestrator(
@@ -374,7 +374,7 @@ def test_orc_datalad_run_container(tmpdir, dataset,
             job_spec={"root_directory": op.join(str(tmpdir), "nm-run"),
                       "outputs": ["out"],
                       "container": "subds/dc",
-                      "command_str": 'sh -c "ls / >out"'})
+                      "_resolved_command_str": 'sh -c "ls / >out"'})
         orc.prepare_remote()
         orc.submit()
         orc.follow()
@@ -432,7 +432,7 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
         os.unlink("local-dirt")
 
     # Run one job so that we create the remote repository.
-    run(command_str="echo one >one")
+    run(_resolved_command_str="echo one >one")
 
     with chpwd(dataset.path):
         orc1 = get_orc()
@@ -443,12 +443,12 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
     os.unlink(op.join(orc1.working_directory, "dirty"))
 
     # We can run if the submodule simply has a different commit checked out.
-    run(command_str="echo two >two")
+    run(_resolved_command_str="echo two >two")
 
     create_tree(op.join(dataset.path, "sub"), {"for-local-commit": ""})
     dataset.add(".", recursive=True)
 
-    run(command_str="echo three >three")
+    run(_resolved_command_str="echo three >three")
 
     # But we abort if subdataset is actually dirty.
     with chpwd(dataset.path):
@@ -560,7 +560,7 @@ def test_orc_datalad_concurrent(job_spec, dataset, ssh, orc_class, sub_type):
 
     job_spec["inputs"] = ["{p[name]}.in"]
     job_spec["outputs"] = ["{p[name]}.out"]
-    job_spec["command_str"] = "sh -c 'cat {inputs} {inputs} >{outputs}'"
+    job_spec["_resolved_command_str"] = "sh -c 'cat {inputs} {inputs} >{outputs}'"
     job_spec["_resolved_batch_parameters"] = [{"name": n} for n in names]
 
     in_files = [n + ".in" for n in names]

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -472,10 +472,10 @@ def test_orc_datalad_abort_if_detached(job_spec, dataset, shell):
 
 
 def test_orc_datalad_resurrect(job_spec, dataset, shell):
-    for k in ["jobid",
+    for k in ["_jobid",
               "working_directory", "root_directory", "local_directory"]:
         job_spec[k] = "doesn't matter"
-    job_spec["head"] = "deadbee"
+    job_spec["_head"] = "deadbee"
     with chpwd(dataset.path):
         orc = orcs.DataladPairOrchestrator(
             shell, submission_type="local", job_spec=job_spec,
@@ -541,8 +541,8 @@ def test_dataset_as_dict(shell, dataset, job_spec):
     d = orc.as_dict()
     # Check for keys that DataladOrchestrator should extend
     # OrchestratorError.asdict() with.
-    assert "head" in d
-    assert "dataset_id" in d
+    assert "_head" in d
+    assert "_dataset_id" in d
 
 
 @pytest.mark.integration

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -174,15 +174,19 @@ def container_dataset(tmpdir_factory):
                           pytest.param("condor", marks=mark.skipif_no_condor)],
                          ids=["sub:local", "sub:condor"])
 def test_orc_datalad_run(job_spec, dataset, shell, orc_class, sub_type):
-    with chpwd(dataset.path):
-        orc = orc_class(shell, submission_type=sub_type, job_spec=job_spec)
-        orc.prepare_remote()
-        orc.submit()
-        orc.follow()
+    def run_and_check(spec):
+        with chpwd(dataset.path):
+            orc = orc_class(shell, submission_type=sub_type, job_spec=spec)
+            orc.prepare_remote()
+            orc.submit()
+            orc.follow()
 
-        orc.fetch()
-        assert dataset.repo.file_has_content("out")
-        assert open("out").read() == "content\nmore\n"
+            orc.fetch()
+            assert dataset.repo.file_has_content("out")
+            assert open("out").read() == "content\nmore\n"
+            return orc
+
+    orc = run_and_check(job_spec)
 
 
 @pytest.mark.integration

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -561,7 +561,7 @@ def test_orc_datalad_concurrent(job_spec, dataset, ssh, orc_class, sub_type):
     job_spec["inputs"] = ["{p[name]}.in"]
     job_spec["outputs"] = ["{p[name]}.out"]
     job_spec["command_str"] = "sh -c 'cat {inputs} {inputs} >{outputs}'"
-    job_spec["batch_parameters"] = [{"name": n} for n in names]
+    job_spec["_resolved_batch_parameters"] = [{"name": n} for n in names]
 
     in_files = [n + ".in" for n in names]
     for fname in in_files:


### PR DESCRIPTION
This series adjusts `run` so that the job spec is included as a file in the `.reproman/jobs/` metadata directory.  This is useful for tracking information about previous runs.  It also provides a base spec file that can be tweaked and passed to `run --job-spec`.  (Right now we don't provide any convenience tooling around reusing a spec, but tracking it allows us to more easily do so in the future.)