### PR TITLE
TST: pytest: Register custom 'integration' mark

### DIFF
--- a/reproman/conftest.py
+++ b/reproman/conftest.py
@@ -21,6 +21,11 @@ def pytest_addoption(parser):
                      default=False, help="run integration tests")
 
 
+def pytest_configure(config):
+    config.addinivalue_line("markers",
+                            "integration: mark test as integration test")
+
+
 def pytest_collection_modifyitems(config, items):
     if config.getoption("--integration"):
         # --integration given in cli: do not skip integration tests


### PR DESCRIPTION
As of pytest 4.5.0, decorating tests with `pytest.mark.integration`
results in this warning:

    PytestUnknownMarkWarning: Unknown pytest.mark.integration - is
    this a typo?  You can register custom marks to avoid this warning
    - for details, see https://docs.pytest.org/en/latest/mark.html

Avoid it by registering 'integration' as a known marker.