### PR TITLE
MNT: Unpin docker-py

### DIFF
--- a/reproman/distributions/tests/test_docker.py
+++ b/reproman/distributions/tests/test_docker.py
@@ -22,7 +22,7 @@ from ...tests.skip import mark
 @mark.skipif_no_network
 @mark.skipif_no_docker_engine
 def test_docker_trace_tag():
-    client = docker.Client()
+    client = docker.APIClient()
     client.pull('alpine:3.6')
 
     tracer = DockerTracer()
@@ -40,7 +40,7 @@ def test_docker_trace_tag():
 @mark.skipif_no_network
 @mark.skipif_no_docker_engine
 def test_docker_trace_id():
-    client = docker.Client()
+    client = docker.APIClient()
     repo_id = 'sha256:f625bd3ff910ad2c68a405ccc5e294d2714fc8cfe7b5d80a8331c72ad5cc7630'
     name = 'alpine@' + repo_id
     client.pull(name)
@@ -62,7 +62,7 @@ def test_docker_trace_id():
 @mark.skipif_no_network
 @mark.skipif_no_docker_engine
 def test_docker_trace_local_image():
-    client = docker.Client()
+    client = docker.APIClient()
     client.pull('alpine:3.6')
     tracer = DockerTracer()
     # Test tracing a local image not saved in a repository
@@ -85,7 +85,7 @@ def test_docker_trace_local_image():
 @mark.skipif_no_docker_engine
 def test_docker_distribution():
 
-    client = docker.Client()
+    client = docker.APIClient()
     session = get_local_session()
 
     # Verify alpine:3.5 image is not stored locally

--- a/reproman/interface/tests/test_create.py
+++ b/reproman/interface/tests/test_create.py
@@ -26,7 +26,7 @@ def test_create_interface():
     Test creating an environment
     """
 
-    with patch('docker.Client') as client, \
+    with patch('docker.APIClient') as client, \
         patch('reproman.resource.ResourceManager.save_inventory'), \
         patch('reproman.resource.ResourceManager._get_inventory'), \
         swallow_logs(new_level=logging.DEBUG) as log:

--- a/reproman/interface/tests/test_delete.py
+++ b/reproman/interface/tests/test_delete.py
@@ -62,7 +62,7 @@ def test_delete_interface():
     Test deleting a resource.
     """
 
-    with patch('docker.Client', new_callable=mock_docker_client) as client, \
+    with patch('docker.APIClient', new_callable=mock_docker_client) as client, \
             patch('reproman.interface.delete.get_manager',
                 new=mock_get_manager), \
             swallow_logs(new_level=logging.DEBUG) as log:

--- a/reproman/interface/tests/test_install.py
+++ b/reproman/interface/tests/test_install.py
@@ -20,7 +20,7 @@ from ...tests.utils import assert_in
 @mark.skipif_no_docker_dependencies
 def test_install_interface(demo1_spec):
 
-    with patch('docker.Client') as client, \
+    with patch('docker.APIClient') as client, \
         patch('reproman.distributions.debian.DebianDistribution.install_packages'), \
         patch('reproman.resource.ResourceManager._get_inventory') as get_inventory, \
         patch('requests.get') as requests, \

--- a/reproman/interface/tests/test_login.py
+++ b/reproman/interface/tests/test_login.py
@@ -23,7 +23,7 @@ def test_login_interface():
     Test logging into an environment
     """
 
-    with patch('docker.Client') as client, \
+    with patch('docker.APIClient') as client, \
         patch('reproman.resource.ResourceManager._get_inventory') as get_inventory, \
         patch('dockerpty.start'), \
         swallow_logs(new_level=logging.DEBUG) as log:

--- a/reproman/interface/tests/test_ls.py
+++ b/reproman/interface/tests/test_ls.py
@@ -57,7 +57,7 @@ def ls_fn(resource_manager):
     def fn(*args, **kwargs):
         skipif.no_docker_dependencies()
         with contextlib.ExitStack() as stack:
-            stack.enter_context(patch("docker.Client"))
+            stack.enter_context(patch("docker.APIClient"))
             stack.enter_context(patch("reproman.interface.ls.get_manager",
                                       return_value=resource_manager))
             return ls(*args, **kwargs)

--- a/reproman/resource/docker_container.py
+++ b/reproman/resource/docker_container.py
@@ -71,7 +71,7 @@ class DockerContainer(Resource):
         """
         from requests.exceptions import ConnectionError
         try:
-            session = docker.Client(base_url=base_url)
+            session = docker.APIClient(base_url=base_url)
             session.info()
         except docker.errors.InvalidConfigFile as exc:
             lgr.error(
@@ -108,7 +108,7 @@ class DockerContainer(Resource):
         Open a connection to the environment.
         """
         # Open a client connection to the Docker engine.
-        self._client = docker.Client(base_url=self.engine_url)
+        self._client = docker.APIClient(base_url=self.engine_url)
 
         containers = []
         for container in self._client.containers(all=True):
@@ -280,7 +280,10 @@ class DockerSession(POSIXSession):
         dest_path = self._prepare_dest_path(src_path, dest_path)
         dest_dir = os.path.dirname(dest_path)
         stream, stat = self.client.get_archive(self.container, src_path)
-        tarball = tarfile.open(fileobj=io.BytesIO(stream.read()))
+        # get_archive() returns a generator with the content (in 2 MB chunks by
+        # default). Consider exposing those chunks as a stream rather than
+        # joining them.
+        tarball = tarfile.open(fileobj=io.BytesIO(b"".join(stream)))
         tarball.extractall(path=dest_dir)
         os.rename(os.path.join(dest_dir, src_basename), dest_path)
 

--- a/reproman/resource/tests/test_docker_container.py
+++ b/reproman/resource/tests/test_docker_container.py
@@ -31,7 +31,7 @@ setup_ubuntu = get_docker_fixture(
 @mark.skipif_no_docker_dependencies
 def test_dockercontainer_class(resman):
 
-    with patch('docker.Client') as client, \
+    with patch('docker.APIClient') as client, \
         patch('dockerpty.start') as dockerpty, \
             swallow_logs(new_level=logging.DEBUG) as log:
 

--- a/reproman/resource/tests/test_session.py
+++ b/reproman/resource/tests/test_session.py
@@ -418,7 +418,7 @@ def test_session_container(location, testing_container, check_methods):
     """
     cls = import_resource(*location)
     import docker
-    client = docker.Client()
+    client = docker.APIClient()
     container = next(c for c in client.containers()
                      if '/testing-container' in c['Names'])
     assert container

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ requires = {
         'chardet',  # python-debian misses dependency on it
     ],
     'docker': [
-        'docker-py>=0.3.2',
+        'docker>=3.0.0',
         'dockerpty',
     ],
     'aws': [


### PR DESCRIPTION
```
The docker module hasn't been released under the name "docker-py"
since 2016 [0] and has seen many releases under the name "docker" [1].
So we've effectively been pinning the release to version 1.10.6 even
though the current version is 4.1.0.

To update to latest version, it looks like we can get by with
substituting APIClient for Client.  Set the new floor to version
2.3.0, the release that introduced APIClient.

[0]: https://pypi.org/project/docker-py
[1]: https://pypi.org/project/docker
```

Closes #387.

---

Light local testing suggests this might work, but let's see what the test run says.  Also, before merging, we should make sure `dockerpty` is hooked up correctly (see gh-387).