### PR TITLE
DOC: Add sections on managing resources and execution

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,7 +5,11 @@
 # Treat warnings as errors.... hierarchy.rst is just a dump of notes ATM
 # SPHINXOPTS    = -W
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+# sphinx-build might be coming from system-wide install, and would
+# use /usr/bin/python3 instead of /usr/bin/env python3, so it would not
+# find our module installed under virtualenv
+SPHINXCMD     = $(shell which sphinx-build)
+SPHINXBUILD   = python3 $(SPHINXCMD)
 PAPER         =
 BUILDDIR      = build
 

--- a/docs/source/acknowledgements.rst
+++ b/docs/source/acknowledgements.rst
@@ -7,7 +7,7 @@ Acknowledgments
 
 ReproMan development is being performed as part of an NIH_ funded
 (1P41EB019936-01A1_) "Center for Reproducible Neuroimaging Computation
-(CRNC)". It's initial development aims to provide a suite of tools for
+(CRNC)". Its initial development aims to provide a suite of tools for
 management of computational environments, which is the TR&D 3 sub-project of
 the CRNC, and is lead by Dr. Halchenko_.
 

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -29,11 +29,25 @@ Environment operations
    generated/man/reproman-stop
    generated/man/reproman-login
 
+
+Command execution
+=================
+
+.. toctree::
+   :maxdepth: 1
+
+   generated/man/reproman-execute
+   generated/man/reproman-run
+   generated/man/reproman-jobs
+
+
 Miscellaneous commands
 ======================
 
 .. toctree::
    :maxdepth: 1
 
+   generated/man/reproman-backend-parameters
+   generated/man/reproman-diff
    generated/man/reproman-retrace
    generated/man/reproman-test

--- a/docs/source/cmdline.rst
+++ b/docs/source/cmdline.rst
@@ -15,8 +15,8 @@ Main command
 
    generated/man/reproman
 
-Environments operations
-=======================
+Environment operations
+======================
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,7 +75,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = u'reproman'
-copyright = u'2016, ReproMan team (in parts DataLad Team)'
+copyright = u'2016-2019, ReproMan team (in parts DataLad Team)'
 author = u'ReproMan team'
 
 # The version info for the project you're documenting, acts as replacement for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -102,7 +102,7 @@ language = None
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
-exclude_patterns = []
+exclude_patterns = ["sandbox/hierarchy.rst"]
 
 # The reST default role (used for this markup: `text`) to use for all
 # documents.

--- a/docs/source/execute.rst
+++ b/docs/source/execute.rst
@@ -50,7 +50,7 @@ where the working tree looks like this::
       |-- f0.csv -> ../.git/annex/objects/[...]
       `-- f1.csv -> ../.git/annex/objects/[...]
 
-The clean.py script takes two positional arguments (e.g., ``./clean.py
+The ``clean.py`` script takes two positional arguments (e.g., ``./clean.py
 data/f0.csv cleaned/f0.csv``), where the first is a data file to process
 and the second is a path to write the output (creating directories if
 necessary).
@@ -74,7 +74,7 @@ calling ``reproman run --list=orchestrators``.
 
 The main orchestrator choices are ``datalad-pair``,
 ``datalad-pair-run``, and ``datalad-local-run``. If the remote has
-DataLad available, you should go with one of the ``pair`` orchestrators.
+DataLad available, you should go with one of the ``datalad-pair*`` orchestrators.
 These will sync your local dataset with a dataset on the remote machine
 (using `datalad publish`_), creating one if it doesn't already exist
 (using `datalad create-sibling`_).
@@ -100,7 +100,7 @@ specify that the ``datalad-pair-run`` orchestrator should be used::
     ./clean.py data/f0.csv cleaned/f0.csv
 
 Notice that in addition to the orchestrator, we specify the input file
-that needs to be available on the remote. If this file were tracked by
+that needs to be available on the remote. If this file was tracked by
 Git rather than by git-annex, we could get by without declaring it as an
 input because the same revision of the dataset is checked out on the
 remote.
@@ -134,7 +134,7 @@ Our last example invocation could be extended to use Condor like so::
 Note that which batch systems are currently supported is mostly a matter
 of which systems ReproMan developers currently have at their disposal.
 If you would like to add support for your system (or have experience
-with more general approach like DRMAA), we'd welcome help in this area.
+with more general approach like DRMAA_), we'd welcome help in this area.
 
 
 Detached jobs
@@ -181,7 +181,7 @@ The ``--batch-spec`` option is the more cumbersome but more flexible
 counterpart to ``--batch-parameter``. Its value should point to a YAML
 file that defines a series of records, each one with all of the
 parameters for a single subjob command. The equivalent of
-``--batch-parameters=f0,f1`` would be a YAML file with the following
+``--batch-parameter name=f0,f1`` would be a YAML file with the following
 content::
 
    - name: f0
@@ -275,3 +275,5 @@ spec.yaml
 .. _datalad run: http://docs.datalad.org/en/latest/generated/man/datalad-run.html
 .. _datalad update: https://datalad.readthedocs.io/en/latest/generated/man/datalad-update.html
 .. _datalad-htcondor: https://github.com/datalad/datalad-htcondor
+
+.. _DRMAA: https://en.wikipedia.org/wiki/DRMAA

--- a/docs/source/execute.rst
+++ b/docs/source/execute.rst
@@ -1,0 +1,277 @@
+.. _execute:
+
+Execute
+*******
+
+Once a resource is present in your inventory (see :ref:`Managing
+resources <manage>`), ReproMan provides a few ways to execute command(s)
+on the resource. The first is to request an interactive shell for a
+resource with :ref:`reproman login <man_reproman-login>`. Another is to
+use :ref:`reproman execute <man_reproman-execute>`, which is suitable
+for running one-off commands on the resource (though, as its manpage
+indicates, it's capable of a bit more). To some degree, you can think of
+``login`` and ``execute`` as analogous to ``ssh HOST`` and ``ssh HOST
+COMMAND``, respectively, where the ReproMan variants provide a common
+interface across resource types.
+
+The final way to execute a command is :ref:`reproman run
+<man_reproman-run>`.
+
+
+Run
+===
+
+.. _rr-tasks:
+
+``reproman run`` is concerned with three high-level tasks:
+
+  1. Starting from a call on the *local* machine, prepare the remote
+     resource for command execution (e.g., copying input files to the
+     remote).
+  2. Execute the command on the remote resource, typically through a
+     batch system.
+  3. Fetch the results to the local machine. The results include command
+     output as well as information about the execution (e.g., batch
+     system submit files).
+
+
+.. _rr-refex:
+
+Reference example
+-----------------
+
+Let's first establish a simple example that we can reference as we cover
+some of the details. In a terminal, we're visiting a `DataLad`_ dataset
+where the working tree looks like this::
+
+  .
+  |-- clean.py
+  `-- data
+      |-- f0.csv -> ../.git/annex/objects/[...]
+      `-- f1.csv -> ../.git/annex/objects/[...]
+
+The clean.py script takes two positional arguments (e.g., ``./clean.py
+data/f0.csv cleaned/f0.csv``), where the first is a data file to process
+and the second is a path to write the output (creating directories if
+necessary).
+
+.. note::
+
+   Although DataLad is not a strict requirement, having it installed on
+   at least the local machine is strongly recommended, and without it
+   only a limited set of functionality is available. If you are new to
+   DataLad, consider reading the `DataLad handbook`_.
+
+
+Choosing an orchestrator
+------------------------
+
+Before running a command, we need to decide on an orchestrator. The
+orchestrator is responsible for the first and third :ref:`tasks above
+<rr-tasks>`, preparing the remote and fetching the results. The complete
+set of orchestrators, accompanied by descriptions, can be seen by
+calling ``reproman run --list=orchestrators``.
+
+The main orchestrator choices are ``datalad-pair``,
+``datalad-pair-run``, and ``datalad-local-run``. If the remote has
+DataLad available, you should go with one of the ``pair`` orchestrators.
+These will sync your local dataset with a dataset on the remote machine
+(using `datalad publish`_), creating one if it doesn't already exist
+(using `datalad create-sibling`_).
+
+``datalad-pair`` differs from the ``datalad-*-run`` orchestrators in the
+way it captures results. After execution has completed, ``datalad-pair``
+commits the result *on the remote* via DataLad. On fetch, it will pull
+that commit down with `datalad update`_. Outputs (specified via
+``--outputs`` or as a job parameter) are retrieved with `datalad get`_.
+
+``datalad-pair-run`` and ``datalad-local-run``, on the other hand,
+determine a list of output files based on modification times and
+packages these files in a tarball. (This approach is inspired by
+`datalad-htcondor`_.) On fetch, this tarball is downloaded locally and
+used to create a `datalad run`_ commit in the *local* repository.
+
+Revisiting :ref:`our concrete example <rr-refex>` and assuming we have
+an SSH resource named "foo" in our inventory, here's how we could
+specify that the ``datalad-pair-run`` orchestrator should be used::
+
+  $ reproman run --resource foo \
+    --orc datalad-pair-run --input data/f0.csv \
+    ./clean.py data/f0.csv cleaned/f0.csv
+
+Notice that in addition to the orchestrator, we specify the input file
+that needs to be available on the remote. If this file were tracked by
+Git rather than by git-annex, we could get by without declaring it as an
+input because the same revision of the dataset is checked out on the
+remote.
+
+.. warning::
+
+   The orchestration with DataLad datasets is work in progress, with
+   some rough edges. You might end up in a state that ReproMan doesn't
+   know how to sync. Please report any issues you encounter on the
+   `issue tracker <https://github.com/ReproNim/reproman/issues/>`_ .
+
+
+.. _rr-sub:
+
+Choosing a submitter
+--------------------
+
+Another, easier decision is which submitter to use. This comes down to
+which, if any, batch system your remote resource supports. The currently
+available options are ``pbs``, ``condor``, or ``local``. With ``local``,
+the job is executed directly through ``sh`` rather than submitted to a
+batch system.
+
+Our last example invocation could be extended to use Condor like so::
+
+  $ reproman run --resource foo \
+     --sub condor \
+     --orc datalad-pair-run --input data/f0.csv \
+    ./clean.py data/f0.csv cleaned/f0.csv
+
+Note that which batch systems are currently supported is mostly a matter
+of which systems ReproMan developers currently have at their disposal.
+If you would like to add support for your system (or have experience
+with more general approach like DRMAA), we'd welcome help in this area.
+
+
+Detached jobs
+-------------
+
+By default, when a ``run`` command is executed, it submits the job,
+registers it locally, and exits. The registered jobs can be viewed and
+managed with :ref:`reproman jobs <man_reproman-jobs>`. To list all jobs,
+run ``reproman jobs`` without any arguments. To fetch a completed job
+back into the local dataset, call ``reproman jobs NAME``, where ``NAME``
+is a substring of the job ID that uniquely identifies the job.
+
+In cases where you prefer ``run`` to stay attached and fetch the job
+when it is finished, pass the ``--follow`` argument to ``reproman run``.
+
+
+Concurrent subjobs
+------------------
+
+If you're submitting a job to a batch system, it's likely that you want
+to submit concurrent subjobs. To continue with the :ref:`toy example
+<rr-refex>` from above, you'd want to have two jobs, each one running
+clean.py on a different input file.
+
+``reproman run`` has two options for specifying subjobs:
+``--batch-parameter`` and ``--batch-spec``. The first can work for
+simple cases, like our example::
+
+  $ reproman run --resource foo --sub condor --orc datalad-pair-run \
+    --batch-parameter name=f0,f1 \
+    --input 'data/{p[name]}.csv'  \
+    ./clean.py data/{p[name]}.csv cleaned/{p[name]}.csv
+
+A subjob will be created for each ``name`` value, with any ``{p[name]}``
+field in the input, output, and command strings formatted with the
+value. In this case, the two commands executed on the remote would be
+
+::
+
+  ./clean.py data/f0.csv cleaned/f0.csv
+  ./clean.py data/f1.csv cleaned/f1.csv
+
+The ``--batch-spec`` option is the more cumbersome but more flexible
+counterpart to ``--batch-parameter``. Its value should point to a YAML
+file that defines a series of records, each one with all of the
+parameters for a single subjob command. The equivalent of
+``--batch-parameters=f0,f1`` would be a YAML file with the following
+content::
+
+   - name: f0
+   - name: f1
+
+.. warning::
+
+   When there is more than one subjob, ``*-run`` orchestrators do not
+   create a valid run commit. Specifically, `datalad rerun`_ could not
+   be used to rerun the commit on the local machine because the values
+   for the inputs, outputs, and command do not correspond to concrete
+   values. This is an unresolved issue, but at this point the commit
+   should be considered as a way to capture the information about the
+   remote command execution---one that certainly provides more
+   information than logging into the remote and running
+   ``condor_submit`` yourself.
+
+
+Job parameters
+--------------
+
+To define a job, ReproMan builds up a "job spec" from job parameters.
+Call ``reproman run --list=parameters`` to see a list of available
+parameters. The parameters can be specified within a file passed to the
+``--job-spec`` option, as a key-value pair specified via the
+``--job-parameter`` option, or through a dedicate command-line option.
+
+The last option is only available for a subset of parameters, with the
+intention of giving these parameters more exposure and making them
+slightly more convenient to use. In the examples so far, we've only seen
+job parameters in the form of a dedicated command-line argument, things
+like ``--orc datalad-pair-run``. Alternatively this could be expressed
+more verbosely through ``--job-parameter`` as ``--job-parameter
+orchestrator=datalad-pair-run``. Or it could be contained as a top-level
+key-value pair in a YAML file passed to ``--job-spec``.
+
+.. _jp_precedence:
+
+When a value is specified in multiple sources, the order of precedence
+is the dedicated option, then the value specified via
+``--job_parameters``, and finally the value contained in a
+``--job-spec`` YAML file. When multiple ``--job-spec`` arguments are
+given and define a conflicting key, the value from the last specified
+file wins.
+
+
+Captured job information
+------------------------
+
+When using any DataLad-based orchestrator, the run will ultimately be
+captured as a commit in the dataset. In addition to working tree changes
+that the command caused (e.g., files it generated), the commit will
+include new files under a ``.reproman/jobs/<resource name>/<job ID>/``
+directory. Of the files from that directory, the ones described below
+are likely to be of the most interest to callers.
+
+submit
+    The batch system submit file (e.g., when the :ref:`submitter
+    <rr-sub>` is ``condor``, the file passed to ``condor_submit``).
+
+runscript
+    The wrapper script called by the submit file. It runs the subjob
+    command indicated by its sole command-line argument, an integer that
+    represents the subjob.
+
+std{out,err}.N
+    The standard output and standard error for each subjob command. If
+    subjob ``N``, ``stderr.N`` is where you should look first for more
+    information.
+
+spec.yaml
+    The "job spec" mentioned in the last section. Any key that does
+    *not* start with an underscore is a job parameter that can be
+    specified by the caller.
+
+    In addition to recording information about the submitted job, this
+    spec can provide a starting point for future ``reproman run`` calls.
+    You can copy it to a new file, tweak it as desired, and feed it in
+    via ``--job-spec``. Or, instead of copying the file, you can give
+    the original file to ``--job-spec`` and then :ref:`override the
+    values <jp_precedence>` as needed with command-line arguments or
+    later ``--job-spec`` values.
+
+
+.. _DataLad: https://www.datalad.org/
+.. _Datalad Handbook: http://handbook.datalad.org
+.. _datalad create-sibling: https://datalad.readthedocs.io/en/latest/generated/man/datalad-create-sibling.html
+.. _datalad get: https://datalad.readthedocs.io/en/latest/generated/man/datalad-get.html
+.. _datalad publish: https://datalad.readthedocs.io/en/latest/generated/man/datalad-publish.html
+.. _datalad rerun: http://docs.datalad.org/en/latest/generated/man/datalad-rerun.html
+.. _datalad run: http://docs.datalad.org/en/latest/generated/man/datalad-run.html
+.. _datalad update: https://datalad.readthedocs.io/en/latest/generated/man/datalad-update.html
+.. _datalad-htcondor: https://github.com/datalad/datalad-htcondor

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,15 @@ Managing resources
    manage
 
 
+Executing commands on resources
+===============================
+
+.. toctree::
+   :maxdepth: 1
+
+   execute
+
+
 Commands and API
 ================
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -18,6 +18,16 @@ Concepts and technologies
    glossary
    sandbox/packages
 
+
+Managing resources
+==================
+
+.. toctree::
+   :maxdepth: 1
+
+   manage
+
+
 Commands and API
 ================
 

--- a/docs/source/manage.rst
+++ b/docs/source/manage.rst
@@ -31,14 +31,15 @@ The output above includes an entry for the SSH resource create above,
 "foo", along with a resource for a Docker container.
 
 While most of the ReproMan subcommands have an argument that specifies
-which resource to operate on, there are only few more dedicated
-subcommands for managing resources: :ref:`stop <man_reproman-stop>`,
-:ref:`start <man_reproman-start>`, and :ref:`delete
-<man_reproman-delete>`. Together ``stop`` and ``start`` provide a way to
-suspend and restart a resource such as a Docker container or an AWS EC2
-instance. For resource types where suspending the resource doesn't make
-sense (e.g., for an ``ssh`` resource), calling ``start`` or ``stop``
-will simply tell you the action isn't supported.
+which resource to operate on (e.g., the resource to :ref:`execute
+<execute>` a command on), there are only few more dedicated subcommands
+for managing resources: :ref:`stop <man_reproman-stop>`, :ref:`start
+<man_reproman-start>`, and :ref:`delete <man_reproman-delete>`. Together
+``stop`` and ``start`` provide a way to suspend and restart a resource
+such as a Docker container or an AWS EC2 instance. For resource types
+where suspending the resource doesn't make sense (e.g., for an ``ssh``
+resource), calling ``start`` or ``stop`` will simply tell you the action
+isn't supported.
 
 ``delete`` is the opposite of ``create``. Calling ``reproman delete
 foo`` would delete the remove the resource created above from ReproMan's

--- a/docs/source/manage.rst
+++ b/docs/source/manage.rst
@@ -1,0 +1,45 @@
+.. _manage:
+
+Managing resources
+******************
+
+ReproMan works with a set of known resources, such as SSH-accessible
+remote machines and local Docker containers. New resources can be added
+with :ref:`reproman create <man_reproman-create>`. The following, for
+example, creates a new ``ssh`` resource named "foo"::
+
+  $ reproman create foo --resource-type ssh --backend-parameters host=foo
+
+This takes advantage of the details about this host being defined in an
+``ssh_config`` configuration file. If a host were not, you could specify
+details like the user and port as additional key-value pairs to
+``--backend-parameters``. To see the full list of the available resource
+types and the associated backend parameters, call :ref:`reproman
+backend-parameters <man_reproman-backend-parameters>`.
+
+Creating a resource adds it to ReproMan's inventory of resources. You
+can inspect resources in ReproMan's inventory with :ref:`reproman ls
+<man_reproman-ls>`::
+
+  $ reproman ls --refresh
+  RESOURCE NAME        TYPE                 ID                  STATUS
+  -------------        ----                 --                  ------
+  buster               docker-container     b29085a427de1efedb6 running
+  foo                  ssh                  7a06ae6b-8097-4c59- ONLINE
+
+The output above includes an entry for the SSH resource create above,
+"foo", along with a resource for a Docker container.
+
+While most of the ReproMan subcommands have an argument that specifies
+which resource to operate on, there are only few more dedicated
+subcommands for managing resources: :ref:`stop <man_reproman-stop>`,
+:ref:`start <man_reproman-start>`, and :ref:`delete
+<man_reproman-delete>`. Together ``stop`` and ``start`` provide a way to
+suspend and restart a resource such as a Docker container or an AWS EC2
+instance. For resource types where suspending the resource doesn't make
+sense (e.g., for an ``ssh`` resource), calling ``start`` or ``stop``
+will simply tell you the action isn't supported.
+
+``delete`` is the opposite of ``create``. Calling ``reproman delete
+foo`` would delete the remove the resource created above from ReproMan's
+inventory.

--- a/docs/source/usecases/index.rst
+++ b/docs/source/usecases/index.rst
@@ -1,5 +1,5 @@
-Environments management use cases
-=================================
+Environment management use cases
+================================
 
 .. TODO migrate use cases from the google doc
 

--- a/formatters.py
+++ b/formatters.py
@@ -169,7 +169,8 @@ class RSTManPageFormatter(ManPageFormatter):
         return usage
 
     def _mk_title(self, prog):
-        title = "{0}".format(prog)
+        title = ".. _man_{}:\n\n".format(prog.replace(' ', '-'))
+        title += "{0}".format(prog)
         title += '\n{0}\n\n'.format('=' * len(title))
         return title
 


### PR DESCRIPTION
This series extends the documentation.  Commits 1-4 are cleanup/setup commits.  Commit 5 adds a page on managing resources, and commit 6 adds a page on execution that's mostly dedicated to `reproman run`.  I'm not sure I'm happy with the state of the `run` parts, but I think it passes the threshold of "more useful than nothing at all".

To generate the html output for review, you can run `make -C docs html`.  Perhaps there's enough here that it's now worth hosting somewhere (probably either readthedocs or github pages).