### PR TITLE
ENH: docker: Pull :latest if no tag or digest is specified

### DIFF
--- a/reproman/resource/docker_container.py
+++ b/reproman/resource/docker_container.py
@@ -30,6 +30,16 @@ import logging
 lgr = logging.getLogger('reproman.resource.docker_container')
 
 
+def _image_latest_default(image):
+    # Given the restricted character set for names, the presence of ":" or "@"
+    # should be a reliable indication of a tag or digest, respectively. See
+    # - https://docs.docker.com/engine/reference/commandline/tag/#extended-description
+    # - vendor/github.com/docker/distribution/reference/regexp.go
+    if ":" not in image and "@" not in image:
+        image += ":latest"
+    return image
+
+
 @attr.s
 class DockerContainer(Resource):
     """
@@ -43,8 +53,10 @@ class DockerContainer(Resource):
     id = attrib()
     type = attrib(default='docker-container')
 
-    image = attrib(default='ubuntu:latest',
-        doc="Docker base image ID from which to create the running instance")
+    image = attrib(
+        default='ubuntu:latest',
+        doc="Docker base image ID from which to create the running instance",
+        converter=_image_latest_default)
     engine_url = attrib(default='unix:///var/run/docker.sock',
         doc="Docker server URL where engine is listening for connections")
     seccomp_unconfined = attrib(default=False,

--- a/reproman/resource/tests/test_docker_container.py
+++ b/reproman/resource/tests/test_docker_container.py
@@ -175,3 +175,12 @@ def test_container_exists(setup_ubuntu):
     from ..docker_container import DockerContainer
     assert DockerContainer.is_container_running(setup_ubuntu['name'])
     assert not DockerContainer.is_container_running('foo')
+
+
+@mark.skipif_no_docker_dependencies
+def test_image_name_latest_default():
+    from ..docker_container import DockerContainer
+    for img, expected in [("debian:buster", "debian:buster"),
+                          ("busybox@ddeeaa", "busybox@ddeeaa"),
+                          ("busybox", "busybox:latest")]:
+        assert DockerContainer(name="cname", image=img).image == expected


### PR DESCRIPTION
If a tag or digest isn't specified when calling `reproman create`, we
download all tagged images.  This behavior will likely be confusing to
any callers that are familiar with the command-line interface to
docker pull, which defaults to :latest if a tag or digest is omitted.
And the behavior doesn't fit our goal: starting a new container from a
single image.

Teach the DockerContainer resource to append ":latest" when it
receives a bare image name.

Closes #483.