### PR TITLE
MNT: Update collections.Mapping for new location

### DIFF
--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -11,6 +11,7 @@
 
 from argparse import REMAINDER
 import collections
+from collections.abc import Mapping
 import glob
 import logging
 import itertools
@@ -56,7 +57,7 @@ def _combine_job_specs(specs):
         Taken from https://stackoverflow.com/a/3233356
         """
         for k, v in u.items():
-            if isinstance(v, collections.Mapping):
+            if isinstance(v, Mapping):
                 d[k] = update(d.get(k, {}), v)
             else:
                 d[k] = v

--- a/reproman/utils.py
+++ b/reproman/utils.py
@@ -7,6 +7,7 @@
 # ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
 
 import collections
+from collections.abc import Mapping
 import re
 
 import builtins
@@ -1431,7 +1432,7 @@ def parse_kv_list(params):
     ------
     ValueError if item in `params` does not match expected "key=value" format.
     """
-    if isinstance(params, collections.Mapping):
+    if isinstance(params, Mapping):
         res = params
     elif params:
         def check_fmt(item):


### PR DESCRIPTION
As of Python 3.3, the ABCs in the collections module are available
from collections.abc.  They remain exposed in `collections` for
compatibility reasons but are slated for removal (originally in Python
3.8, now in 3.9).