### PR TITLE
RF: use python not python3 for running sphinx-build

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -9,7 +9,7 @@ SPHINXOPTS    =
 # use /usr/bin/python3 instead of /usr/bin/env python3, so it would not
 # find our module installed under virtualenv
 SPHINXCMD     = $(shell which sphinx-build)
-SPHINXBUILD   = python3 $(SPHINXCMD)
+SPHINXBUILD   = python $(SPHINXCMD)
 PAPER         =
 BUILDDIR      = build
 


### PR DESCRIPTION
To resolve a hypothetical issue of no python3 executable being
available, while still allowing for virtualenv and system-wide
installation of sphinx.

I will merge if does not cause any breakage in CI