### PR TITLE
ENH: use etelemetry to check for a newer version available upon running a command or importing .api

### DIFF
--- a/reproman/api.py
+++ b/reproman/api.py
@@ -17,6 +17,9 @@ def _generate_func_api():
     from .interface.base import get_interface_groups
     from .interface.base import get_api_name
     from .interface.base import alter_interface_docs_for_api
+    from .utils import check_available_version
+
+    check_available_version()
 
     for grp_name, grp_descr, interfaces in get_interface_groups():
         for intfspec in interfaces:

--- a/reproman/cmdline/main.py
+++ b/reproman/cmdline/main.py
@@ -23,7 +23,7 @@ import reproman
 
 from reproman.cmdline import helpers
 from reproman.support.exceptions import InsufficientArgumentsError, MissingConfigFileError
-from ..utils import setup_exceptionhook, chpwd
+from ..utils import setup_exceptionhook, check_available_version, chpwd
 from ..dochelpers import exc_str
 
 
@@ -242,6 +242,8 @@ def main(args=None):
     if not hasattr(cmdlineargs, 'func'):
         lgr.info("No command given, returning")
         return
+
+    check_available_version()
 
     ret = None
     if cmdlineargs.common_debug or cmdlineargs.common_idebug:

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ requires = {
         'appdirs',
         'attrs>=16.3.0',
         'humanize',
+        'etelemetry',
         'pyyaml',
         'tqdm',
         'fabric>=2.3.1',


### PR DESCRIPTION
It already helped me to realize that I forgot to "release" 0.2.* on Github.
Now they are released, so I guess it takes etelemetry service some time to update
its knowledge.  Hopefully tomorrow we should see the effect.

Attn @satra who might provide recommendation and also I wonder if it would be worth trying to generalize such `check_available_version` and ship it within etelemtry-client itself, so users did not have to reimplement similar logic. Could have signature like
```
check_available_version(github_project, current_version, info, debug)
```
where `info` and `debug` will be the callable (with the same signature as of the logger) to use.  What do you think @satra ?

TODOs:
- [ ] Wrap the entire body to be ran in a separate thread. Even though it might not be taking long, IMHO it might be of benefit to cmdline apps to not spend time waiting