### PR TITLE
run: Add Slurm support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - REPROMAN_TESTS_SSH=1
     - INSTALL_DATALAD=1
     - INSTALL_CONDOR=1
+    - SETUP_SLURM=1
   - python: 3.5
     env:
     - REPROMAN_TESTS_SSH=1
@@ -65,6 +66,9 @@ before_install:
   - if [ ! -z "${REPROMAN_TESTS_SSH:-}" ]; then
       sudo eatmydata tools/ci/prep-travis-forssh-sudo.sh;
       tools/ci/prep-travis-forssh.sh;
+    fi
+  - if [ ! -z "${SETUP_SLURM:-}" ]; then
+      tools/ci/setup-slurm-container.sh;
     fi
   - git config --global user.email "test@travis.land"
   - git config --global user.name "Travis Almighty"

--- a/reproman/support/jobs/job_templates/submission/slurm.template
+++ b/reproman/support/jobs/job_templates/submission/slurm.template
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+#SBATCH --output={{ shlex_quote(_meta_directory) }}/stdout.%a
+#SBATCH --error={{ shlex_quote(_meta_directory) }}/stderr.%a
+{#
+  TODO: We need to assess how we treat batch parameters across different
+  submitters---things like whether we should try to expose common names and, if
+  so, what are the discrepancies in the behavior, and how should we deal with
+  that. We should also revisit the goal of making it possible for the caller to
+  extend the submit file template to add stuff like parameters we do not expose
+  and environment modules.
+#}
+{% if memory is defined %}
+#SBATCH --mem={{ memory }}
+{% endif %}
+{% if num_processes is defined %}
+#SBATCH --cpus-per-task={{ num_processes }}
+{% endif %}
+{% if _num_subjobs == 1 %}
+#SBATCH --array=0
+{% else %}
+#SBATCH --array=0-{{ _num_subjobs - 1}}
+{% endif %}
+
+{{ shlex_quote(_meta_directory) }}/runscript $SLURM_ARRAY_TASK_ID

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -55,6 +55,14 @@ def ssh():
     return SSH("testssh", host="reproman-test")
 
 
+@pytest.fixture(scope="module")
+def ssh_slurm():
+    skipif.no_ssh()
+    skipif.no_slurm()
+    from reproman.resource.ssh import SSH
+    return SSH("slurm-res", host="slurm")
+
+
 def test_orc_root_directory(shell):
     orc = orcs.PlainOrchestrator(shell, submission_type="local")
     assert orc.root_directory == op.expanduser("~/.reproman/run-root")
@@ -220,6 +228,11 @@ def check_orc_datalad(job_spec, dataset):
                          ids=["sub:local", "sub:condor"])
 def test_orc_datalad_run(check_orc_datalad, shell, orc_class, sub_type):
     check_orc_datalad(shell, orc_class, sub_type)
+
+
+@pytest.mark.integration
+def test_orc_datalad_slurm(check_orc_datalad, ssh_slurm):
+    check_orc_datalad(ssh_slurm, orcs.DataladLocalRunOrchestrator, "slurm")
 
 
 @pytest.mark.integration
@@ -630,3 +643,10 @@ def check_orc_datalad_concurrent(job_spec, dataset):
 def test_orc_datalad_concurrent(check_orc_datalad_concurrent,
                                 ssh, orc_class, sub_type):
     check_orc_datalad_concurrent(ssh, orc_class, sub_type)
+
+
+@pytest.mark.integration
+def test_orc_datalad_concurrent_slurm(check_orc_datalad_concurrent, ssh_slurm):
+    check_orc_datalad_concurrent(ssh_slurm,
+                                 orcs.DataladLocalRunOrchestrator,
+                                 "slurm")

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -166,6 +166,49 @@ def container_dataset(tmpdir_factory):
     return ds
 
 
+@pytest.fixture()
+def check_orc_datalad(job_spec, dataset):
+    def fn(resource, orc_class, sub_type):
+        dataset.repo.tag("start-pt")
+
+        def run_and_check(spec):
+            with chpwd(dataset.path):
+                orc = orc_class(resource,
+                                submission_type=sub_type, job_spec=spec)
+                orc.prepare_remote()
+                orc.submit()
+                orc.follow()
+
+                orc.fetch()
+                assert dataset.repo.file_has_content("out")
+                assert open("out").read() == "content\nmore\n"
+                return orc
+
+        orc = run_and_check(job_spec)
+
+        # Perform another run based on the dumped job spec from the first.
+        assert dataset.repo.get_active_branch() == "master"
+        metadir = op.relpath(orc.meta_directory, orc.working_directory)
+        with open(op.join(dataset.path, metadir, "spec.yaml")) as f:
+            dumped_spec = yaml.safe_load(f)
+            assert "_reproman_version" in dumped_spec
+            assert "_spec_version" in dumped_spec
+        if orc.name == "datalad-local-run":
+            # Our reproman-based copying of data doesn't isn't (yet) OK with
+            # data files that already exist.
+            dumped_spec["inputs"] = []
+        # FIXME: Use exposed method once available.
+        dataset.repo._git_custom_command(
+            [], ["git", "reset", "--hard", "start-pt"])
+        if dataset.repo.dirty:
+            # The submitter log file is ignored (currently only relevant for
+            # condor; see b9277ebc0 for more details). Add the directory to get
+            # to a clean state.
+            dataset.add(".reproman")
+        orc = run_and_check(dumped_spec)
+    return fn
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize("orc_class",
                          [orcs.DataladLocalRunOrchestrator,
@@ -175,43 +218,8 @@ def container_dataset(tmpdir_factory):
                          ["local",
                           pytest.param("condor", marks=mark.skipif_no_condor)],
                          ids=["sub:local", "sub:condor"])
-def test_orc_datalad_run(job_spec, dataset, shell, orc_class, sub_type):
-    dataset.repo.tag("start-pt")
-
-    def run_and_check(spec):
-        with chpwd(dataset.path):
-            orc = orc_class(shell, submission_type=sub_type, job_spec=spec)
-            orc.prepare_remote()
-            orc.submit()
-            orc.follow()
-
-            orc.fetch()
-            assert dataset.repo.file_has_content("out")
-            assert open("out").read() == "content\nmore\n"
-            return orc
-
-    orc = run_and_check(job_spec)
-
-    # Perform another run based on the dumped job spec from the first.
-    assert dataset.repo.get_active_branch() == "master"
-    metadir = op.relpath(orc.meta_directory, orc.working_directory)
-    with open(op.join(dataset.path, metadir, "spec.yaml")) as f:
-        dumped_spec = yaml.safe_load(f)
-        assert "_reproman_version" in dumped_spec
-        assert "_spec_version" in dumped_spec
-    if orc.name == "datalad-local-run":
-        # Our reproman-based copying of data doesn't isn't (yet) OK with data
-        # files that already exist.
-        dumped_spec["inputs"] = []
-    # FIXME: Use exposed method once available.
-    dataset.repo._git_custom_command(
-        [], ["git", "reset", "--hard", "start-pt"])
-    if dataset.repo.dirty:
-        # The submitter log file is ignored (currently only relevant for
-        # condor; see b9277ebc0 for more details). Add the directory to get to
-        # a clean state.
-        dataset.add(".reproman")
-    orc = run_and_check(dumped_spec)
+def test_orc_datalad_run(check_orc_datalad, shell, orc_class, sub_type):
+    check_orc_datalad(shell, orc_class, sub_type)
 
 
 @pytest.mark.integration
@@ -574,6 +582,41 @@ def test_dataset_as_dict(shell, dataset, job_spec):
     assert "_dataset_id" in d
 
 
+@pytest.fixture()
+def check_orc_datalad_concurrent(job_spec, dataset):
+    def fn(ssh, orc_class, sub_type):
+        names = ["paul", "rosa"]
+
+        job_spec["inputs"] = ["{p[name]}.in"]
+        job_spec["outputs"] = ["{p[name]}.out"]
+        job_spec["_resolved_command_str"] = "sh -c 'cat {inputs} {inputs} >{outputs}'"
+        job_spec["_resolved_batch_parameters"] = [{"name": n} for n in names]
+
+        in_files = [n + ".in" for n in names]
+        for fname in in_files:
+            with open(op.join(dataset.path, fname), "w") as fh:
+                fh.write(fname[0])
+        dataset.save(path=in_files)
+
+        with chpwd(dataset.path):
+            orc = orc_class(ssh, submission_type=sub_type, job_spec=job_spec)
+            orc.prepare_remote()
+            orc.submit()
+            orc.follow()
+            # Just make sure each fetch() seems to have wired up
+            # on_remote_finish. test_run.py tests the actual --follow actions.
+            remote_fn = MagicMock()
+            orc.fetch(on_remote_finish=remote_fn)
+            remote_fn.assert_called_once_with(orc.resource, [])
+
+            out_files = [n + ".out" for n in names]
+            for ofile in out_files:
+                assert dataset.repo.file_has_content(ofile)
+                with open(ofile) as ofh:
+                    assert ofh.read() == ofile[0] * 2
+    return fn
+
+
 @pytest.mark.integration
 @pytest.mark.parametrize("orc_class",
                          [orcs.DataladLocalRunOrchestrator,
@@ -584,33 +627,6 @@ def test_dataset_as_dict(shell, dataset, job_spec):
                          ["local",
                           pytest.param("condor", marks=mark.skipif_no_condor)],
                          ids=["sub:local", "sub:condor"])
-def test_orc_datalad_concurrent(job_spec, dataset, ssh, orc_class, sub_type):
-    names = ["paul", "rosa"]
-
-    job_spec["inputs"] = ["{p[name]}.in"]
-    job_spec["outputs"] = ["{p[name]}.out"]
-    job_spec["_resolved_command_str"] = "sh -c 'cat {inputs} {inputs} >{outputs}'"
-    job_spec["_resolved_batch_parameters"] = [{"name": n} for n in names]
-
-    in_files = [n + ".in" for n in names]
-    for fname in in_files:
-        with open(op.join(dataset.path, fname), "w") as fh:
-            fh.write(fname[0])
-    dataset.save(path=in_files)
-
-    with chpwd(dataset.path):
-        orc = orc_class(ssh, submission_type=sub_type, job_spec=job_spec)
-        orc.prepare_remote()
-        orc.submit()
-        orc.follow()
-        # Just make sure each fetch() seems to have wired up on_remote_finish.
-        # test_run.py tests the actual --follow actions.
-        remote_fn = MagicMock()
-        orc.fetch(on_remote_finish=remote_fn)
-        remote_fn.assert_called_once_with(orc.resource, [])
-
-        out_files = [n + ".out" for n in names]
-        for ofile in out_files:
-            assert dataset.repo.file_has_content(ofile)
-            with open(ofile) as ofh:
-                assert ofh.read() == ofile[0] * 2
+def test_orc_datalad_concurrent(check_orc_datalad_concurrent,
+                                ssh, orc_class, sub_type):
+    check_orc_datalad_concurrent(ssh, orc_class, sub_type)

--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -113,6 +113,18 @@ def no_singularity():
             not external_versions["cmd:singularity"])
 
 
+def no_slurm():
+    def is_running():
+        # Does it look like tools/ci/setup-slurm-container.sh was called?
+        try:
+            out, _ = Runner().run(
+                ["docker", "port", "reproman-slurm-container"])
+        except CommandError:
+            return False
+        return out.strip()
+    return "slurm container is not running", not is_running()
+
+
 def no_ssh():
     if _on_windows:
         reason = "no ssh on windows"
@@ -140,6 +152,7 @@ CONDITION_FNS = [
     no_docker_engine,
     no_network,
     no_singularity,
+    no_slurm,
     no_ssh,
     no_svn,
     on_windows,

--- a/tools/ci/setup-slurm-container.sh
+++ b/tools/ci/setup-slurm-container.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+set -eu
+
+if ! test -f /tmp/rman-test-ssh-id
+then
+    echo "prep-travis-forssh.sh needs to executed before this script" >&2
+    exit 1
+fi
+
+cat >>~/.ssh/config <<'EOF'
+
+Host slurm
+HostName localhost
+Port 42241
+User root
+StrictHostKeyChecking no
+IdentityFile /tmp/rman-test-ssh-id
+EOF
+
+docker run --name reproman-slurm-container \
+       -dit -p 42241:22 -h ernie \
+       repronim/reproman-slurm:latest
+
+cat /tmp/rman-test-ssh-id.pub \
+    | docker exec -i reproman-slurm-container \
+             sh -c 'cat >>/root/.ssh/authorized_keys'
+
+# Without the sleep below, the ssh call fails with
+#
+#   ssh_exchange_identification: read: Connection reset by peer
+#
+# A 10 second sleep is probably longer than we need, but a 3 second sleep did
+# not seem to be enough:
+# https://travis-ci.org/ReproNim/reproman/jobs/627568055#L584
+sleep 10
+
+echo "DEBUG: test connection to slurm container ..."
+ssh -v slurm exit


### PR DESCRIPTION
This is an initial stab at Slurm support (gh-484).  There are still things to flesh out (most of the known ones should have to-do comment placeholders), and I bet someone familiar with Slurm could suggest better ways to do things (e.g., is it possible to get the job status as a JSON record?).  But I was able to submit simple commands (with a single job and with multiple subjobs), so things seem to be wired up correctly at least at a basic level.

---

Given that I don't have access to an environment with Slurm, setting that up was the more involved part.  Here are the details:

<details>
<summary>Slurm setup</summary>

* Clone <https://github.com/giovtorres/slurm-docker-cluster>

* Apply the patch at the end of this post.  It configures the image for ssh.  A few of the changes in that diff might not be strictly necessary, but I didn't spend much time fiddling with it once I got something working.

* Build the image: `docker build -t slurm-docker-cluster:19.05.1 .`  This takes a bit of time because it builds Slurm from source.

* Run `docker-compose up -d` and then `./register_cluster.sh`.

* I didn't specify a host port in docker-compose.yml, so check the assigned port (`docker port slurmctld 22`).

* Add an entry to .ssh/config for the slurmctld container along the lines of

  ```
  ...
  Host slurm
  HostName <IP>
  User root
  ControlMaster no
  Port <N>
  ```

* `ssh-copy-id slurm` so that you don't have to worry about entering the password ("root").

Then we're to the standard reproman stuff:

* `reproman create sl -t ssh -b host=slurm`

* Create some datalad dataset and run something like `reproman run -r sl --follow --orc datalad-local-run --submitter=slurm --jp root_directory=/data --bp say=a,b sh -c "sleep 10; echo i say {p[say]} >{p[say]}"`

Notice the `root_directory`.  slurm-docker-cluster's README.md says to submit the jobs from that mount point, and I think that's necessary to make things work, but I haven't really looked into it.

</details>

<details>
<summary>sshd patch</summary>

```diff
diff --git a/Dockerfile b/Dockerfile
index d143635..197e92d 100644
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,8 @@ RUN set -ex \
        psmisc \
        bash-completion \
        vim-enhanced \
+       openssh-clients \
+       openssh-server \
     && yum clean all \
     && rm -rf /var/cache/yum

@@ -83,10 +85,21 @@ RUN set -x \
     && chown -R slurm:slurm /var/*/slurm* \
     && /sbin/create-munge-key

+RUN echo 'root:root' |chpasswd
+
+RUN sed -ri 's/^#?PermitRootLogin\s+.*/PermitRootLogin yes/' /etc/ssh/sshd_config
+RUN sed -ri 's/UsePAM yes/#UsePAM yes/g' /etc/ssh/sshd_config
+
+RUN mkdir /root/.ssh
+
 COPY slurm.conf /etc/slurm/slurm.conf
 COPY slurmdbd.conf /etc/slurm/slurmdbd.conf

 COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

+EXPOSE 22
+ENV NOTVISIBLE "in users profile"
+RUN echo "export VISIBLE=now" >> /etc/profile
+
 CMD ["slurmdbd"]
diff --git a/docker-compose.yml b/docker-compose.yml
index f0862be..74fcb0e 100644
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,8 +37,11 @@ services:
       - etc_slurm:/etc/slurm
       - slurm_jobdir:/data
       - var_log_slurm:/var/log/slurm
+    ports:
+      - "22"
     expose:
       - "6817"
+      - "22"
     depends_on:
       - "slurmdbd"

diff --git a/docker-entrypoint.sh b/docker-entrypoint.sh
index 9a1203a..1a7a16f 100755
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -23,6 +23,10 @@ fi

 if [ "$1" = "slurmctld" ]
 then
+    echo "---> Starting sshd ..."
+    ssh-keygen -A
+    /usr/sbin/sshd
+
     echo "---> Starting the MUNGE Authentication service (munged) ..."
     gosu munge /usr/sbin/munged

```

</details>
