### PR TITLE
jobs: Treat deleted local directory as orchestrator error

### DIFF
--- a/reproman/interface/jobs.py
+++ b/reproman/interface/jobs.py
@@ -217,6 +217,6 @@ class Jobs(Interface):
                     fn(job)
                 except OrchestratorError as exc:
                     lgr.error("job %s failed: %s", job, exc_str(exc))
-                except ResourceNotFoundError as exc:
+                except ResourceNotFoundError:
                     lgr.error("Resource %s (%s) no longer exists",
                               job["resource_id"], job["resource_name"])

--- a/reproman/interface/jobs.py
+++ b/reproman/interface/jobs.py
@@ -216,7 +216,7 @@ class Jobs(Interface):
                 try:
                     fn(job)
                 except OrchestratorError as exc:
-                    lgr.error("job %s failed: %s", job, exc_str(exc))
+                    lgr.error("job %s failed: %s", job["_jobid"], exc_str(exc))
                 except ResourceNotFoundError:
                     lgr.error("Resource %s (%s) no longer exists",
                               job["resource_id"], job["resource_name"])

--- a/reproman/interface/tests/test_run.py
+++ b/reproman/interface/tests/test_run.py
@@ -13,6 +13,7 @@ import logging
 from unittest.mock import patch
 import os
 import os.path as op
+import shutil
 import time
 
 import pytest
@@ -453,6 +454,18 @@ def test_jobs_deleted_resource(context):
             assert "todelete" not in output.out
             # ... but the alive one will.
             assert "myshell" in output.out
+
+
+def test_jobs_deleted_local_directory(context):
+    path = context["directory"]
+    run = context["run_fn"]
+    jobs = context["jobs_fn"]
+
+    run(command=["touch", "ok"], outputs=["ok"], resref="myshell")
+    shutil.rmtree(path)
+    with swallow_logs(new_level=logging.ERROR) as log:
+        jobs(queries=[], status=True)
+        assert "no longer exists" in log.out
 
 
 def test_jobs_orc_error(context):

--- a/reproman/interface/tests/test_run.py
+++ b/reproman/interface/tests/test_run.py
@@ -183,14 +183,16 @@ def context(tmpdir, resource_manager, job_registry):
     - directory: temporary path that is the current directory when run_fn is
       called.
     """
-    path = str(tmpdir)
+    home = str(tmpdir)
+    path = op.join(home, "local")
+    os.makedirs(path, exist_ok=True)
 
     def run_fn(*args, **kwargs):
         with contextlib.ExitStack() as stack:
             stack.enter_context(chpwd(path))
             # Patch home to avoid populating testing machine with jobs when
             # using local shell.
-            stack.enter_context(patch.dict(os.environ, {"HOME": path}))
+            stack.enter_context(patch.dict(os.environ, {"HOME": home}))
             stack.enter_context(patch("reproman.interface.run.get_manager",
                                       return_value=resource_manager))
             stack.enter_context(patch("reproman.interface.run.LocalRegistry",


### PR DESCRIPTION
The first two commits are minor clean-ups around the same code path as the title issue, which is addressed by the final commit.