### PR TITLE
travis: Fix failing master branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ matrix:
     env:
     - REPROMAN_LOGLEVEL=2
     - REPROMAN_LOGTARGET=/dev/null
-  - python: 3.4
+  - python: 3.6
     # Note: This this no network run appears to hang or otherwise
     # behave oddly on 3.5.
     env:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,7 @@ we outline the workflow used by the developers:
 Development environment
 -----------------------
 
-We support Python 3 (>= 3.4).
+We support Python 3 (>= 3.5).
 
 See [README.md:Dependencies](README.md#Dependencies) for basic information
 about installation of reproman itself.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ internals and/or contributing to the project.
 
 # Installation
 
-ReproMan requires Python 3 (>= 3.4).
+ReproMan requires Python 3 (>= 3.5).
 
 ## Debian-based systems
 

--- a/setup.py
+++ b/setup.py
@@ -144,7 +144,7 @@ setup(
     description="Neuroimaging Computational Environments Manager",
     long_description=long_description,
     packages=reproman_pkgs,
-    python_requires='>=3.4',
+    python_requires='>=3.5',
     install_requires=requires['core'],
     extras_require=requires,
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ setup(
     description="Neuroimaging Computational Environments Manager",
     long_description=long_description,
     packages=reproman_pkgs,
+    python_requires='>=3.4',
     install_requires=requires['core'],
     extras_require=requires,
     entry_points={

--- a/tools/ci/install_datalad
+++ b/tools/ci/install_datalad
@@ -7,5 +7,5 @@ sudo apt-get install git-annex-standalone
 # Install datalad system-wide for use with localhost ssh
 sudo apt-get install datalad
 # ... and install it into the virtualenv.
-pip install git+https://github.com/datalad/datalad.git
+pip install datalad
 pip install datalad-container


### PR DESCRIPTION
Fix the [failing Travis build with master][0] by (1) bumping our required Python version to 3.5 and (2) using a released version of DataLad.

[0]: https://travis-ci.org/chaselgrove/reproman/builds/652585399

Closes #503