### PR TITLE
Updates for (unrelased) DataLad 0.13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
   - python: 3.5
     env:
     - REPROMAN_TESTS_SSH=1
+    - REPROMAN_TESTS_DEPS=full
     - INSTALL_DATALAD=1
     - INSTALL_CONDOR=1
     - SETUP_SLURM=1
@@ -55,7 +56,7 @@ matrix:
 
 env:
   global:
-    - REPROMAN_TESTS_DEPS=full
+    - REPROMAN_TESTS_DEPS=full-except-datalad
 
 before_install:
   # we do not need anything from those APT sources, and they often fail, disable!

--- a/reproman/support/jobs/job_templates/runscript/datalad-pair-run.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/datalad-pair-run.template.sh
@@ -5,7 +5,7 @@
 
 prev_commit=$(git rev-parse HEAD)
 
-{% include "includes/datalad-add.template.sh" %}
+{% include "includes/datalad-save.template.sh" %}
 
 {% include "includes/create-ref.template.sh" %}
 

--- a/reproman/support/jobs/job_templates/runscript/datalad-pair.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/datalad-pair.template.sh
@@ -2,7 +2,7 @@
 
 {% block post_command %}
 
-{% include "includes/datalad-add.template.sh" %}
+{% include "includes/datalad-save.template.sh" %}
 
 {% include "includes/create-ref.template.sh" %}
 

--- a/reproman/support/jobs/job_templates/runscript/includes/datalad-save.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/includes/datalad-save.template.sh
@@ -1,5 +1,5 @@
 {# Send stdout/stderr to /dev/null because this stdin/stdout is dumped to files
-   in .reproman and we don't want to change the content mid-add.  Note that we
+   in .reproman and we don't want to change the content mid-save.  Note that we
    don't bother adding .reproman in a separate step because it may be added if
    the leading path includes a hidden directory.
 #}
@@ -10,4 +10,4 @@ msg={{ shlex_quote(message) }}
 {% else %}
 msg="[ReproMan] save results for $jobid"
 {% endif %}
-datalad add --recursive -m"$msg" . .reproman >/dev/null 2>&1
+datalad save --recursive -m"$msg" . .reproman >/dev/null 2>&1

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -895,6 +895,13 @@ def head_at(dataset, commit):
         lgr.info("Checking out %s", commit)
         try:
             dataset.repo.checkout(commit)
+            # Note: It's tempting try to use --recurse-submodules here, but
+            # that will absorb submodule's .git/ directories, and DataLad
+            # relies on plain .git/ directories.
+            if dataset.repo.dirty:
+                raise OrchestratorError(
+                    "Refusing to move HEAD due to submodule state change "
+                    "within {}".format(dataset.path))
             yield moved
         finally:
             lgr.info("Restoring checkout of %s", to_restore)

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -921,7 +921,8 @@ class FetchDataladPairMixin(object):
         ref = self.job_refname
         lgr.info("Updating local dataset with changes from '%s'",
                  resource_name)
-        self.ds.repo.fetch(resource_name, "{0}:{0}".format(ref))
+        self.ds.repo.fetch(resource_name, "{0}:{0}".format(ref),
+                           recurse_submodules="no")
         self.ds.update(sibling=resource_name,
                        merge=True, recursive=True)
         lgr.info("Getting outputs from '%s'", resource_name)

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -736,15 +736,6 @@ class PrepareRemoteDataladMixin(object):
         inputs = list(self.get_inputs())
         if isinstance(session, SSHSession):
             if resource.key_filename:
-                dl_version = external_versions["datalad"]
-                if dl_version < "0.11.3":
-                    # Connecting will probably fail because `key_filename` is
-                    # set, but we have no way to tell DataLad about it.
-                    lgr.warning(
-                        "DataLad version %s detected. "
-                        "0.11.3 or greater is required to use an "
-                        "identity file not specified in ~/.ssh/config",
-                        dl_version)
                 # Make the identity file available to 'datalad sshrun' even if
                 # it is not configured in .ssh/config. This is particularly
                 # important for AWS keys.

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -42,7 +42,6 @@ from reproman.resource.ssh import SSHSession
 from reproman.support.jobs.submitters import SUBMITTERS
 from reproman.support.jobs.template import Template
 from reproman.support.exceptions import CommandError
-from reproman.support.exceptions import MissingExternalDependency
 from reproman.support.exceptions import OrchestratorError
 from reproman.support.external_versions import external_versions
 
@@ -484,10 +483,7 @@ class DataladOrchestrator(Orchestrator, metaclass=abc.ABCMeta):
 
     def __init__(self, resource, submission_type, job_spec=None,
                  resurrection=False):
-        if not external_versions["datalad"]:
-            raise MissingExternalDependency(
-                "DataLad is required for orchestrator '{}'".format(self.name))
-
+        external_versions.check("datalad", min_version="0.13")
         super(DataladOrchestrator, self).__init__(
             resource, submission_type, job_spec, resurrection=resurrection)
 

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -694,6 +694,10 @@ class PrepareRemoteDataladMixin(object):
         """Try to get datataset and subdatasets into the correct state.
         """
         self._checkout_target()
+        # fixup 0: 'datalad create-sibling --recursive' leaves the subdataset
+        # uninitialized (see DataLad's 78e00dcd2).
+        self._execute_in_wdir(["git", "submodule", "update", "--init"])
+
         # fixup 1: Check out target commit in subdatasets. This should later be
         # replaced by the planned Datalad functionality to get an entire
         # dataset hierarchy to a recorded state.

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -580,33 +580,11 @@ class PrepareRemotePlainMixin(object):
 
 
 def _format_ssh_url(user, host, port, path):
-    """Format an SSH URL for DataLad, considering installed version.
-    """
-    if external_versions["datalad"] >= "0.11.2":
-        fmt = "ssh://{user}{host}{port}{path}"
-        warn = False
-    else:
-        # Stick to git scp-like syntax because create-sibling will fail with
-        # something like
-        #
-        #   stderr: 'fatal: ssh variant 'simple' does not support setting port'
-        #   [cmd.py:wait:415] (GitCommandError)
-        #
-        # with the default value of ssh.variant. For non-standard ports, this
-        # relies on the user setting up their ssh config.
-        fmt = "{user}{host}:{path}"
-        warn = port is not None
-        port = None
-    sshurl = fmt.format(user=user + "@" if user else "",
-                        host=host,
-                        port=":" + str(port) if port is not None else "",
-                        path=path)
-
-    if warn:
-        lgr.warning("Using SSH url %s; "
-                    "port should be specified in SSH config",
-                    sshurl)
-    return sshurl
+    return "ssh://{user}{host}{port}{path}".format(
+        user=user + "@" if user else "",
+        host=host,
+        port=":" + str(port) if port is not None else "",
+        path=path)
 
 
 class PrepareRemoteDataladMixin(object):

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -552,8 +552,8 @@ class DataladOrchestrator(Orchestrator, metaclass=abc.ABCMeta):
              "**/failed/* annex.largefiles=nothing\n"
              "idmap annex.largefiles=nothing\n"))
 
-        self.ds.add([gitignore, gitattrs],
-                    message="[ReproMan] Configure jobs directory")
+        self.ds.save([gitignore, gitattrs],
+                     message="[ReproMan] Configure jobs directory")
 
 
 # Orchestrator method mixins

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -769,8 +769,6 @@ class PrepareRemoteDataladMixin(object):
                         "Either delete remote or rename resource."
                         .format(resource.name))
 
-                self.ds.create_sibling(target_path, name=resource.name,
-                                       recursive=True)
                 since = None  # Avoid since="" for non-existing repo.
             else:
                 remote_branch = "{}/{}".format(
@@ -782,6 +780,9 @@ class PrepareRemoteDataladMixin(object):
                     # If the remote branch doesn't exist yet, publish will fail
                     # with since="".
                     since = None
+
+            self.ds.create_sibling(target_path, name=resource.name,
+                                   recursive=True, existing="skip")
 
             for res in self.ds.publish(to=resource.name, since=since,
                                        recursive=True, on_failure="ignore"):

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -451,10 +451,10 @@ def _datalad_format_command(ds, spec):
 
     Create "*_array" keys and format commands with DataLad's `format_command`.
     """
-    from datalad.interface.run import format_command
+    from datalad.core.local.run import format_command
     # DataLad's GlobbedPaths _should_ be the same as ours, but let's use
     # DataLad's to avoid potential discrepancies with datalad-run's behavior.
-    from datalad.interface.run import GlobbedPaths
+    from datalad.core.local.run import GlobbedPaths
 
     batch_parameters = spec.get("_resolved_batch_parameters") or [{}]
     spec["_command_array"] = []
@@ -1009,7 +1009,7 @@ class FetchDataladRunMixin(object):
                 os.unlink(tfile)
                 # TODO: How to handle output cleanup on the remote?
 
-                from datalad.interface.run import run_command
+                from datalad.core.local.run import run_command
                 lgr.info("Creating run commit in %s", self.ds.path)
 
                 cmds = self.job_spec["_command_array"]

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -783,14 +783,13 @@ class PrepareRemoteDataladMixin(object):
                     # with since="".
                     since = None
 
-            from datalad.support.exceptions import IncompleteResultsError
-            try:
-                self.ds.publish(to=resource.name, since=since, recursive=True)
-            except IncompleteResultsError:
-                raise OrchestratorError(
-                    "'datalad publish' failed. Try running "
-                    "'datalad update -s {} --merge --recursive' first"
-                    .format(resource.name))
+            for res in self.ds.publish(to=resource.name, since=since,
+                                       recursive=True, on_failure="ignore"):
+                lgr.debug("datalad publish result: %s", res)
+                if res["status"] == "error":
+                    raise OrchestratorError(
+                        "'datalad publish' failed: {}"
+                        .format(res))
 
             self._fix_up_dataset()
 

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -205,9 +205,7 @@ def check_orc_datalad(job_spec, dataset):
             # Our reproman-based copying of data doesn't isn't (yet) OK with
             # data files that already exist.
             dumped_spec["inputs"] = []
-        # FIXME: Use exposed method once available.
-        dataset.repo._git_custom_command(
-            [], ["git", "reset", "--hard", "start-pt"])
+        dataset.repo.call_git(["reset", "--hard", "start-pt"])
         if dataset.repo.dirty:
             # The submitter log file is ignored (currently only relevant for
             # condor; see b9277ebc0 for more details). Add the directory to get
@@ -549,8 +547,7 @@ def test_head_at_unknown_ref(dataset):
 
 def test_head_at_empty_branch(dataset):
     dataset.repo.checkout("orph", options=["--orphan"])
-    # FIXME: Use expose method once available.
-    dataset.repo._git_custom_command([], ["git", "reset", "--hard"])
+    dataset.repo.call_git(["reset", "--hard"])
     assert not dataset.repo.dirty
     with pytest.raises(OrchestratorError) as exc:
         with orcs.head_at(dataset, "master"):

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -647,3 +647,21 @@ def test_orc_datalad_concurrent_slurm(check_orc_datalad_concurrent, ssh_slurm):
     check_orc_datalad_concurrent(ssh_slurm,
                                  orcs.DataladLocalRunOrchestrator,
                                  "slurm")
+
+
+def test_orc_datalad_pair_submodule(job_spec, dataset, shell):
+    # Smoke test that triggers the failure from gh-499
+    with chpwd(dataset.path):
+        dataset.create("sub")
+        dataset.save()
+
+        job_spec["_resolved_command_str"] = "sh -c 'echo foo >sub/foo'"
+        job_spec["inputs"] = []
+        job_spec["outputs"] = []
+
+        orc = orcs.DataladPairOrchestrator(
+            shell, submission_type="local", job_spec=job_spec)
+        orc.prepare_remote()
+        orc.submit()
+        orc.follow()
+        orc.fetch()

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -205,7 +205,7 @@ def check_orc_datalad(job_spec, dataset):
             # Our reproman-based copying of data doesn't isn't (yet) OK with
             # data files that already exist.
             dumped_spec["inputs"] = []
-        dataset.repo.call_git(["reset", "--hard", "start-pt"])
+        dataset.repo.call_git(["checkout", "-b", "other", "start-pt"])
         if dataset.repo.dirty:
             # The submitter log file is ignored (currently only relevant for
             # condor; see b9277ebc0 for more details). Add the directory to get

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -152,7 +152,7 @@ def dataset(tmpdir_factory):
     create_tree(ds.path, {"foo": "foo",
                           "bar": "bar",
                           "d": {"in": "content\n"}})
-    ds.add(".")
+    ds.save()
     ds.repo.tag("root")
     return ds
 
@@ -212,7 +212,7 @@ def check_orc_datalad(job_spec, dataset):
             # The submitter log file is ignored (currently only relevant for
             # condor; see b9277ebc0 for more details). Add the directory to get
             # to a clean state.
-            dataset.add(".reproman")
+            dataset.save(".reproman")
         orc = run_and_check(dumped_spec)
     return fn
 
@@ -246,7 +246,7 @@ def test_orc_datalad_run_change_head(job_spec, dataset, shell):
 
         create_tree(dataset.path, {"sinceyouvebeengone":
                                    "imsomovingon,yeahyeah"})
-        dataset.add(".")
+        dataset.save()
 
         orc.fetch()
         ref = "refs/reproman/{}".format(orc.jobid)
@@ -364,7 +364,7 @@ def test_orc_datalad_pair_run_ontop(job_spec, dataset, ssh):
     #   o
     ds = dataset
     create_tree(ds.path, {"in": "content\n"})
-    ds.add(".")
+    ds.save()
 
     js0 = job_spec
     js1 = dict(job_spec, _resolved_command_str='bash -c "echo other >other"')
@@ -496,7 +496,7 @@ def test_orc_datalad_abort_if_dirty(job_spec, dataset, ssh):
     run(_resolved_command_str="echo two >two")
 
     create_tree(op.join(dataset.path, "sub"), {"for-local-commit": ""})
-    dataset.add(".", recursive=True)
+    dataset.save(recursive=True)
 
     run(_resolved_command_str="echo three >three")
 
@@ -562,7 +562,7 @@ def test_head_at_no_move(dataset):
     with orcs.head_at(dataset, "master") as moved:
         assert not moved
         create_tree(dataset.path, {"on-master": "on-maser"})
-        dataset.add("on-master", message="advance master")
+        dataset.save("on-master", message="advance master")
         assert dataset.repo.get_active_branch() == "master"
     assert dataset.repo.get_active_branch() == "master"
 
@@ -572,13 +572,13 @@ def test_head_at_move(dataset):
         return op.exists(op.join(dataset.path, path))
 
     create_tree(dataset.path, {"pre": "pre"})
-    dataset.add("pre")
+    dataset.save("pre")
     with orcs.head_at(dataset, "master~1") as moved:
         assert moved
         assert dataset.repo.get_active_branch() is None
         assert not dataset_path_exists("pre")
         create_tree(dataset.path, {"at-head": "at-head"})
-        dataset.add("at-head", message="advance head (not master)")
+        dataset.save("at-head", message="advance head (not master)")
     assert dataset_path_exists("pre")
     assert not dataset_path_exists("at-head")
     assert dataset.repo.get_active_branch() == "master"

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,12 @@ requires = {
         #'http://archive.ubuntu.com/ubuntu/pool/main/p/python-apt/python-apt_0.9.3.5.tar.xz'
         'chardet',  # python-debian misses dependency on it
     ],
+    'datalad': [
+        # Drop the rc as soon as we can to avoid installing future
+        # rcs. See https://github.com/datalad/datalad-container/pull/74.
+        'datalad>=0.13.0rc2',
+        'datalad-container',
+    ],
     'docker': [
         'docker>=3.0.0',
         'dockerpty',
@@ -83,7 +89,11 @@ requires = {
     ]
 }
 
+# Target to ease testing installation.
+requires['full-except-datalad'] = [v for k, vs in requires.items()
+                                   for v in vs if k != "datalad"]
 requires['full'] = sum(list(requires.values()), [])
+
 
 # Now add additional ones useful for development
 requires.update({

--- a/tools/ci/install_datalad
+++ b/tools/ci/install_datalad
@@ -7,5 +7,5 @@ sudo apt-get install git-annex-standalone
 # Install datalad system-wide for use with localhost ssh
 sudo apt-get install datalad
 # ... and install it into the virtualenv.
-pip install datalad
+pip install git+https://github.com/datalad/datalad.git
 pip install datalad-container

--- a/tools/ci/install_datalad
+++ b/tools/ci/install_datalad
@@ -6,6 +6,3 @@ sudo apt-get install git-annex-standalone
 
 # Install datalad system-wide for use with localhost ssh
 sudo apt-get install datalad
-# ... and install it into the virtualenv.
-pip install git+https://github.com/datalad/datalad.git
-pip install datalad-container


### PR DESCRIPTION
This series updates `run`-related functionality for changes in the next feature release of DataLad.  That version will contain some functionality that was prompted by issues on ReproMan's end, in particular improvements to `datalad update` and `datalad create-sibling`.

The changes above will require bumping our dependency to DataLad 0.13.0, so other commits in this series prune no longer needed compatibility kludges.  In addition, 0.13 removes the deprecated `datalad add` command, so a commit here migrates to `datalad save` (which was held off to retain compatibility with DataLad 0.11.x line).

I'm marking this as a draft because (1) this shouldn't be merged until DataLad 0.13.0 is released and (2) this should resolve at least a few open issues, but I still need to reference them in the commit messages and add relevant tests.  The latter will probably point out the need for at least minor tweaks.
