### PR TITLE
Fix miniconda download

### DIFF
--- a/reproman/distributions/conda.py
+++ b/reproman/distributions/conda.py
@@ -87,7 +87,7 @@ def get_miniconda_url(conda_platform, python_version):
     platform += "-x86_64" if ("64" in conda_platform) else "-x86"
     # FIXME: We need to update this our conda tracer to work with conda's newer
     # than 4.6.14. See gh-443.
-    return "https://repo.continuum.io/miniconda/Miniconda%s-4.6.14-%s.sh" \
+    return "https://repo.anaconda.com/miniconda/Miniconda%s-4.6.14-%s.sh" \
                     % (python_version[0], platform)
 
 

--- a/reproman/distributions/conda.py
+++ b/reproman/distributions/conda.py
@@ -184,8 +184,10 @@ class CondaDistribution(Distribution):
                 # TODO: Determine if we can detect miniconda vs anaconad
                 miniconda_url = get_miniconda_url(self.platform,
                                                   self.python_version)
-                session.execute_command("curl %s -o %s/miniconda.sh" %
-                                        (miniconda_url, tmp_dir))
+                session.execute_command(
+                    "curl --fail --silent --show-error --location "
+                    "--output {}/miniconda.sh {}"
+                    .format(tmp_dir, miniconda_url))
                 # NOTE: miniconda.sh makes parent directories automatically
                 session.execute_command("bash -b %s/miniconda.sh -b -p %s" %
                                         (tmp_dir, self.path))

--- a/reproman/distributions/tests/test_conda.py
+++ b/reproman/distributions/tests/test_conda.py
@@ -33,11 +33,11 @@ def test_get_conda_platform_from_python():
 
 def test_get_miniconda_url():
     assert get_miniconda_url("linux-64", "2.7") == \
-           "https://repo.continuum.io/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh"
+           "https://repo.anaconda.com/miniconda/Miniconda2-4.6.14-Linux-x86_64.sh"
     assert get_miniconda_url("linux-32", "3.4") == \
-           "https://repo.continuum.io/miniconda/Miniconda3-4.6.14-Linux-x86.sh"
+           "https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-Linux-x86.sh"
     assert get_miniconda_url("osx-64", "3.5.1") == \
-           "https://repo.continuum.io/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh"
+           "https://repo.anaconda.com/miniconda/Miniconda3-4.6.14-MacOSX-x86_64.sh"
 
 
 def test_get_simple_python_version():


### PR DESCRIPTION
The download is failing due to a new redirect, causing `test_conda_init_install_and_detect` to fail.  Update the URL, and also tweak the `curl` call to avoid this issue in the future.

This isn't the full rework that our conda functionality needs (gh-446), but it's a prerequisite for that and should put master back into a passing state.