### PR TITLE
TST: skip: Quiet Runner-based dependency checks

### DIFF
--- a/reproman/cmd.py
+++ b/reproman/cmd.py
@@ -249,8 +249,12 @@ class Runner(object):
 
             except Exception as e:
                 prot_exc = e
-                lgr.error("Failed to start %r%r: %s" %
-                          (cmd, " under %r" % cwd if cwd else '', exc_str(e)))
+                if isinstance(e, FileNotFoundError) and expect_fail:
+                    logfn = lgr.debug
+                else:
+                    logfn = lgr.error
+                logfn("Failed to start %r%r: %s" %
+                      (cmd, " under %r" % cwd if cwd else '', exc_str(e)))
                 raise
 
             finally:

--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -46,24 +46,24 @@ _runner = Runner()
 
 def _get_annex_version():
     """Return version of available git-annex"""
-    return _runner.run('git annex version --raw'.split())[0]
+    return _runner.run(['git', 'annex', 'version', '--raw'])[0]
 
 
 def _get_git_version():
     """Return version of available git"""
-    return _runner.run('git version'.split())[0].split()[-1]
+    return _runner.run(['git', 'version'])[0].split()[-1]
 
 
 def _get_apt_cache_version():
     """Return version of available apt-cache."""
-    return _runner.run('apt-cache -v'.split())[0].split()[1]
+    return _runner.run(['apt-cache', '-v'])[0].split()[1]
 
 
 def _get_system_ssh_version():
     """Return version of ssh available system-wide
     """
     try:
-        out, err = _runner.run('ssh -V'.split(),
+        out, err = _runner.run(['ssh', '-V'],
                                expect_fail=True, expect_stderr=True)
         # apparently spits out to err but I wouldn't trust it blindly
         if err.startswith('OpenSSH'):

--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -46,17 +46,22 @@ _runner = Runner()
 
 def _get_annex_version():
     """Return version of available git-annex"""
-    return _runner.run(['git', 'annex', 'version', '--raw'])[0]
+    return _runner.run(['git', 'annex', 'version', '--raw'],
+                       expect_fail=True, expect_stderr=True)[0]
 
 
 def _get_git_version():
     """Return version of available git"""
-    return _runner.run(['git', 'version'])[0].split()[-1]
+    out = _runner.run(['git', 'version'],
+                      expect_fail=True, expect_stderr=True)[0]
+    return out.split()[-1]
 
 
 def _get_apt_cache_version():
     """Return version of available apt-cache."""
-    return _runner.run(['apt-cache', '-v'])[0].split()[1]
+    out = _runner.run(['apt-cache', '-v'],
+                      expect_fail=True, expect_stderr=True)[0]
+    return out.split()[1]
 
 
 def _get_system_ssh_version():
@@ -80,7 +85,8 @@ def _get_singularity_version():
     # example output:
     #  "singularity version 3.0.3+ds"
     #  "2.6.1-dist"
-    out = _runner.run(["singularity", "--version"])[0]
+    out = _runner.run(["singularity", "--version"],
+                      expect_fail=True, expect_stderr=True)[0]
     return out.split(' ')[-1].split("-")[0].split("+")[0]
 
 
@@ -90,7 +96,9 @@ def _get_svn_version():
     #
     # svn, version 1.9.5 (r1770682)
     # [...]
-    return _runner.run(["svn", "--version"])[0].split()[2]
+    out = _runner.run(["svn", "--version"],
+                      expect_fail=True, expect_stderr=True)[0]
+    return out.split()[2]
 
 
 def _get_condor_version():
@@ -98,7 +106,9 @@ def _get_condor_version():
     # Example output:
     #
     # $CondorVersion: 8.6.8 Nov 30 2017 BuildID: [...]
-    return _runner.run(['condor_version'])[0].split()[1]
+    out = _runner.run(['condor_version'],
+                      expect_fail=True, expect_stderr=True)[0]
+    return out.split()[1]
 
 
 class ExternalVersions(object):

--- a/reproman/support/external_versions.py
+++ b/reproman/support/external_versions.py
@@ -44,23 +44,24 @@ from reproman.support.exceptions import (
 _runner = Runner()
 
 
+def _try_run(cmd):
+    return _runner.run(cmd, expect_fail=True, expect_stderr=True)
+
+
 def _get_annex_version():
     """Return version of available git-annex"""
-    return _runner.run(['git', 'annex', 'version', '--raw'],
-                       expect_fail=True, expect_stderr=True)[0]
+    return _try_run(['git', 'annex', 'version', '--raw'])[0]
 
 
 def _get_git_version():
     """Return version of available git"""
-    out = _runner.run(['git', 'version'],
-                      expect_fail=True, expect_stderr=True)[0]
+    out = _try_run(['git', 'version'])[0]
     return out.split()[-1]
 
 
 def _get_apt_cache_version():
     """Return version of available apt-cache."""
-    out = _runner.run(['apt-cache', '-v'],
-                      expect_fail=True, expect_stderr=True)[0]
+    out = _try_run(['apt-cache', '-v'])[0]
     return out.split()[1]
 
 
@@ -68,8 +69,7 @@ def _get_system_ssh_version():
     """Return version of ssh available system-wide
     """
     try:
-        out, err = _runner.run(['ssh', '-V'],
-                               expect_fail=True, expect_stderr=True)
+        out, err = _try_run(['ssh', '-V'])
         # apparently spits out to err but I wouldn't trust it blindly
         if err.startswith('OpenSSH'):
             out = err
@@ -85,8 +85,7 @@ def _get_singularity_version():
     # example output:
     #  "singularity version 3.0.3+ds"
     #  "2.6.1-dist"
-    out = _runner.run(["singularity", "--version"],
-                      expect_fail=True, expect_stderr=True)[0]
+    out = _try_run(["singularity", "--version"])[0]
     return out.split(' ')[-1].split("-")[0].split("+")[0]
 
 
@@ -96,8 +95,7 @@ def _get_svn_version():
     #
     # svn, version 1.9.5 (r1770682)
     # [...]
-    out = _runner.run(["svn", "--version"],
-                      expect_fail=True, expect_stderr=True)[0]
+    out = _try_run(["svn", "--version"])[0]
     return out.split()[2]
 
 
@@ -106,8 +104,7 @@ def _get_condor_version():
     # Example output:
     #
     # $CondorVersion: 8.6.8 Nov 30 2017 BuildID: [...]
-    out = _runner.run(['condor_version'],
-                      expect_fail=True, expect_stderr=True)[0]
+    out = _try_run(['condor_version'])[0]
     return out.split()[1]
 
 

--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -70,7 +70,7 @@ def no_condor():
         try:
             Runner().run(["condor_status"],
                          expect_fail=True, expect_stderr=True)
-        except CommandError as exc:
+        except (CommandError, FileNotFoundError):
             return False
         return True
 
@@ -121,7 +121,7 @@ def no_slurm():
             out, _ = Runner().run(
                 ["docker", "port", "reproman-slurm-container"],
                 expect_fail=True, expect_stderr=True)
-        except CommandError:
+        except (CommandError, FileNotFoundError):
             return False
         return out.strip()
     return "slurm container is not running", not is_running()

--- a/reproman/tests/skip.py
+++ b/reproman/tests/skip.py
@@ -68,7 +68,8 @@ def no_aws_dependencies():
 def no_condor():
     def is_running():
         try:
-            Runner().run(["condor_status"])
+            Runner().run(["condor_status"],
+                         expect_fail=True, expect_stderr=True)
         except CommandError as exc:
             return False
         return True
@@ -118,7 +119,8 @@ def no_slurm():
         # Does it look like tools/ci/setup-slurm-container.sh was called?
         try:
             out, _ = Runner().run(
-                ["docker", "port", "reproman-slurm-container"])
+                ["docker", "port", "reproman-slurm-container"],
+                expect_fail=True, expect_stderr=True)
         except CommandError:
             return False
         return out.strip()


### PR DESCRIPTION
The point is to check whether the functionality is available, so don't
pollute the test output with alarming things like

    [ERROR  ] stderr| Error: communication error [..]
    [ERROR  ] Failed to run ['condor_status'] under None. [...]

---

This is just a minor cosmetic thing that was bothering me as I was working on another topic.