### PR TITLE
runscript: Improve status file checks

### DIFF
--- a/reproman/support/jobs/job_templates/runscript/base.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/base.template.sh
@@ -53,7 +53,7 @@ then
 # least for now, below is a brittle solution were the last job waits until it
 # sees that all other jobs have exited and then runs the post-command stuff.
 nstatus () {
-    find "$metadir" -regex '.*/status\.[0-9]+' | wc -l
+    find "$metadir" -regex '.*/status\.[0-9][0-9]*' | wc -l
 }
 
 # Ugly, but this sleep makes it less likely for the post-command tar to fail

--- a/reproman/support/jobs/job_templates/runscript/base.template.sh
+++ b/reproman/support/jobs/job_templates/runscript/base.template.sh
@@ -53,7 +53,7 @@ then
 # least for now, below is a brittle solution were the last job waits until it
 # sees that all other jobs have exited and then runs the post-command stuff.
 nstatus () {
-    find "$metadir" -regex '.*/status\.[0-9][0-9]*' | wc -l
+    grep -E '^(succeed|fail)' "$metadir"/status.* | wc -l
 }
 
 # Ugly, but this sleep makes it less likely for the post-command tar to fail


### PR DESCRIPTION
This series has a commit from @chaselgrove and one from @yarikoptic.  The first commit isn't strictly needed because the second drops the `find` call, but I think it is good to have that change in case we end up going back to a `find` call.

Based on looking at <https://ss64.com/osx/grep.html>, I think this grep call should be okay on macOS.