### PR TITLE
ENH: small tune ups to "jobs -s" output in case of missing external (datalad)

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -486,7 +486,8 @@ class DataladOrchestrator(Orchestrator, metaclass=abc.ABCMeta):
                  resurrection=False):
         if not external_versions["datalad"]:
             raise MissingExternalDependency(
-                "DataLad is required for orchestrator '{}'".format(self.name))
+                "datalad",
+                msg="Required for orchestrator '{}'".format(self.name))
 
         super(DataladOrchestrator, self).__init__(
             resource, submission_type, job_spec, resurrection=resurrection)


### PR DESCRIPTION
See individual commits.  Now would show
```
$> reproman --dbg jobs -s
[status: N/A - needs datalad] 20200107-213600-f814 on smaug via condor$ '{inputs}' '{outputs}' participant --participan...
...
```
instead of immediately crashing with 
```
$> reproman  jobs -s    
2020-05-25 20:18:57,108 [ERROR  ] DataLad is required for orchestrator 'datalad-pair-run' is missing. [orchestrators.py:__init__:488] (MissingExternalDependency) 
```