### PR TITLE
ENH: provide a more informative KeyError by listing known ones 

### DIFF
--- a/reproman/support/collections.py
+++ b/reproman/support/collections.py
@@ -1,0 +1,34 @@
+# ex: set sts=4 ts=4 sw=4 noet:
+# ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+#
+#   See COPYING file distributed along with the reproman package for the
+#   copyright and license terms.
+#
+#   Originally written by Yaroslav Halchenko  for Fail2Ban and later
+#   adopted for use in DataLad and ReproMan and thus relicensed under MIT/Expat.
+#   Relicensing was conveyed via email to other contributors.
+#
+#  ## ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ### ##
+from __future__ import absolute_import
+
+import collections
+
+
+class UnknownKeyError(KeyError):
+    def __init__(self, *args, known=None):
+        super().__init__(*args)
+        self.known = known
+
+    def __str__(self):
+        return super().__str__() + ". Known keys: %s" % ', '.join(map(str, self.known or []))
+
+
+class KnownKeysDict(collections.OrderedDict):
+    """A derived class which would provide a KeyError message listing available keys
+    """
+
+    def __getitem__(self, item):
+        try:
+            return super().__getitem__(item)
+        except KeyError as exc:
+            raise UnknownKeyError(*exc.args, known=list(self)) from exc

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -39,6 +39,7 @@ from reproman.utils import cached_property
 from reproman.utils import chpwd
 from reproman.utils import write_update
 from reproman.resource.ssh import SSHSession
+from reproman.support.collections import KnownKeysDict
 from reproman.support.jobs.submitters import SUBMITTERS
 from reproman.support.jobs.template import Template
 from reproman.support.exceptions import CommandError
@@ -1158,7 +1159,7 @@ class DataladLocalRunOrchestrator(
     name = "datalad-local-run"
 
 
-ORCHESTRATORS = collections.OrderedDict(
+ORCHESTRATORS = KnownKeysDict(
     (o.name, o) for o in [
         PlainOrchestrator,
         DataladPairOrchestrator,


### PR DESCRIPTION
To provide an informative error message like:
```shell
$> reproman run --follow -r local --sub local --orc bogus --bp "pl=1,2" echo '{p[pl]}'     
2020-05-25 21:18:07,772 [ERROR  ] 'bogus'. Known keys: plain, datalad-pair, datalad-pair-run, datalad-local-run [collections.py:__getitem__:34] (UnknownKeyError) 
```
instead of 
```
2020-05-25 21:18:51,813 [ERROR  ] 'bogus' [run.py:__call__:406] (KeyError) 
```
which would require user to RTFM instead of fixing up the invocation

TODOs
- [ ] Better name - may be `SimpleRegistry` to signal the purpose of those use-cases?
- [ ] may be enhance with suggestions using `difflib.get_close_matches` if anything closeish
- [ ] basic tests
- [ ] Apply to other structs in addition to ORCHESTRATORs
