### PR TITLE
ENH: run: Specify constraints for --sub and --orc

### DIFF
--- a/reproman/interface/run.py
+++ b/reproman/interface/run.py
@@ -226,11 +226,13 @@ class Run(Interface):
         submitter=Parameter(
             args=("--submitter", "--sub"),
             metavar="NAME",
+            constraints=EnsureChoice(None, *SUBMITTERS),
             doc=(JOB_PARAMETERS["submitter"] +
                  "[CMD:  Use --list to see available submitters CMD]")),
         orchestrator=Parameter(
             args=("--orchestrator", "--orc"),
             metavar="NAME",
+            constraints=EnsureChoice(None, *ORCHESTRATORS),
             doc=(JOB_PARAMETERS["orchestrator"] +
                  "[CMD:  Use --list to see available orchestrators CMD]")),
         batch_spec=Parameter(


### PR DESCRIPTION
If an invalid value for the submitter or orchestrator is given, run()
fails with an uninformative KeyError.  Add the accepted values as
constraints so that run() fails early with a helpful message.

This is an alternative to gh-517.

Suggested-by: @yarikoptic