### PR TITLE
run: Add orchestrator for local, in-place runs

### DIFF
--- a/docs/source/execute.rst
+++ b/docs/source/execute.rst
@@ -91,6 +91,11 @@ packages these files in a tarball. (This approach is inspired by
 `datalad-htcondor`_.) On fetch, this tarball is downloaded locally and
 used to create a `datalad run`_ commit in the *local* repository.
 
+There is one more orchestrator, ``datalad-no-remote``, that is designed
+to work only with a local shell resource. It is similar to
+``datalad-pair``, except that the command is executed in the same
+directory from which ``reproman run`` is invoked.
+
 Revisiting :ref:`our concrete example <rr-refex>` and assuming we have
 an SSH resource named "foo" in our inventory, here's how we could
 specify that the ``datalad-pair-run`` orchestrator should be used::

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -497,7 +497,8 @@ def call_check_dl_results(fn, failure_msg, *args, **kwds):
     """
     for res in fn(*args, **kwds):
         lgr.debug("datalad publish result: %s", res)
-        if res["status"] in ["error", "impossible"]:
+        if res["status"] not in ["ok", "notneeded"]:
+
             raise OrchestratorError("{}: {}".format(failure_msg, res))
 
 

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -442,9 +442,8 @@ def test_orc_datalad_pair(job_spec, dataset, shell):
         orc.follow()
 
         orc.fetch()
-        # The local fetch variant doesn't currently get the content, so just
-        # check that the file is under annex.
         assert dataset.repo.is_under_annex("out")
+        assert (dataset.pathobj / "out").exists()
 
 
 @pytest.mark.integration

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -466,7 +466,7 @@ def test_orc_datalad_no_remote_get(tmpdir, shell, should_pass):
     with chpwd(ds_b.path):
         orc = orcs.DataladNoRemoteOrchestrator(
             shell, submission_type="local",
-            job_spec={"root_directory": op.join(topdir, "nm-run"),
+            job_spec={"root_directory": op.join(topdir, "run-root"),
                       "inputs": ["foo"],
                       "outputs": ["out"],
                       "_resolved_command_str": 'sh -c "cat foo foo >out"'})


### PR DESCRIPTION
This series, in particular the second commit, adds a new orchestrator to support the use case described in gh-460.

---

- [x] Improve test coverage of patch.
