### PR TITLE
run: Don't abort if sibling unexpectedly exists but has expected target

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -765,10 +765,19 @@ class PrepareRemoteDataladMixin(object):
             if not session.exists(self.working_directory):
                 remotes = repo.get_remotes()
                 if resource.name in remotes:
-                    raise OrchestratorError(
-                        "Remote '{}' unexpectedly exists. "
-                        "Either delete remote or rename resource."
-                        .format(resource.name))
+                    if repo.get_remote_url(resource.name) != target_path:
+                        raise OrchestratorError(
+                            "Remote '{}' already exists with another URL. "
+                            "Either delete remote or rename resource."
+                            .format(resource.name))
+                    else:
+                        lgr.debug(
+                            "Remote '%s' matches resource name "
+                            "and points to the expected target, "
+                            "which doesn't exist.  "
+                            "Removing remote and recreating",
+                            resource.name)
+                        repo.remove_remote(resource.name)
 
                 since = None  # Avoid since="" for non-existing repo.
             else:

--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -728,7 +728,8 @@ class PrepareRemoteDataladMixin(object):
     def prepare_remote(self):
         """Prepare dataset sibling on remote.
         """
-        if not self.ds.repo.get_active_branch():
+        repo = self.ds.repo
+        if not repo.get_active_branch():
             # publish() fails when HEAD is detached.
             raise OrchestratorError(
                 "You must be on a branch to use the {} orchestrator"
@@ -762,7 +763,7 @@ class PrepareRemoteDataladMixin(object):
             # TODO: Add one level deeper with reckless clone per job to deal
             # with concurrent jobs?
             if not session.exists(self.working_directory):
-                remotes = self.ds.repo.get_remotes()
+                remotes = repo.get_remotes()
                 if resource.name in remotes:
                     raise OrchestratorError(
                         "Remote '{}' unexpectedly exists. "
@@ -773,8 +774,8 @@ class PrepareRemoteDataladMixin(object):
             else:
                 remote_branch = "{}/{}".format(
                     resource.name,
-                    self.ds.repo.get_active_branch())
-                if self.ds.repo.commit_exists(remote_branch):
+                    repo.get_active_branch())
+                if repo.commit_exists(remote_branch):
                     since = ""
                 else:
                     # If the remote branch doesn't exist yet, publish will fail
@@ -931,11 +932,12 @@ class FetchDataladPairMixin(object):
         ref = self.job_refname
         lgr.info("Updating local dataset with changes from '%s'",
                  resource_name)
-        self.ds.repo.fetch(resource_name, "{0}:{0}".format(ref),
-                           recurse_submodules="no")
+        repo = self.ds.repo
+        repo.fetch(resource_name, "{0}:{0}".format(ref),
+                   recurse_submodules="no")
         failure = False
         try:
-            self.ds.repo.merge(ref)
+            repo.merge(ref)
         except DCError as exc:
             lgr.warning(
                 "Failed to merge in changes from %s. "

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -788,3 +788,18 @@ def test_orc_datalad_pair_new_submodule(job_spec, dataset, shell):
         orc.follow()
         orc.fetch()
         assert sub.repo.is_under_annex("a")
+
+
+def test_orc_datalad_pair_existing_remote(job_spec, dataset, shell):
+    root_directory = job_spec["root_directory"]
+    dataset.repo.add_remote("localshell", "i-dont-match")
+    with chpwd(dataset.path):
+        orc = orcs.DataladPairOrchestrator(
+            shell, submission_type="local", job_spec=job_spec)
+        # If a remote with the resource name exists, we abort if the
+        # URL doesn't match the expected target...
+        with pytest.raises(OrchestratorError):
+            orc.prepare_remote()
+        # ... and continue if it does.
+        dataset.repo.set_remote_url("localshell", orc.working_directory)
+        orc.prepare_remote()


### PR DESCRIPTION
If the target directory on the remote doesn't exist, `DataladOrchestrator.prepare_remote()` checks whether a sibling of the same name exists and aborts if it does.  In gh-440, @yarikoptic points out that this is unnecessarily strict:

> I think that ideally it should not even complain/crash if remote is configured and has desired target path (I believe it is the fact here)

This series addresses that bit of gh-440.
