### PR TITLE
BF: orchestrators: Don't try to get outputs if ref merge fails

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -941,6 +941,7 @@ class FetchDataladPairMixin(object):
                 "Failed to merge in changes from %s. "
                 "Check %s for merge conflicts. %s",
                 ref, self.ds.path, exc_str(exc))
+            failure = True
         else:
             # Handle any subdataset updates. We could avoid this if we knew
             # there were no subdataset changes, but it's probably simplest to


### PR DESCRIPTION
As of cdce12249 (ENH: orchestrators(datalad-pair): Do a more targeted
update, 2020-04-09), we first try to merge in the job ref, and if that
fails, update() isn't called.  Set failure=True so that we do not try
to get output files with a working tree that has not been updated.

Reported-by: @yarikoptic
https://github.com/ReproNim/reproman/pull/527#discussion_r435427464