### PR TITLE
ls: Give non-zero exit code when an unknown resource is specified

### DIFF
--- a/reproman/interface/ls.py
+++ b/reproman/interface/ls.py
@@ -14,6 +14,7 @@ __docformat__ = 'restructuredtext'
 from collections import OrderedDict
 
 from .base import Interface
+from .common_opts import resref_type_opt
 # import reproman.interface.base  # Needed for test patching
 from ..support.param import Parameter
 from ..resource import get_manager
@@ -51,10 +52,12 @@ class Ls(Interface):
             nargs="*",
             doc="Restrict the output to this resource name or ID"
         ),
+        resref_type=resref_type_opt,
     )
 
     @staticmethod
-    def __call__(resrefs=None, verbose=False, refresh=False):
+    def __call__(resrefs=None, resref_type="auto", verbose=False,
+                 refresh=False):
         id_length = 19  # todo: make it possible to output them long
         template = '{:<20} {:<20} {:<%(id_length)s} {!s:<10}' % locals()
         ui.message(template.format('RESOURCE NAME', 'TYPE', 'ID', 'STATUS'))
@@ -68,7 +71,7 @@ class Ls(Interface):
 
         for resref in resrefs:
             try:
-                resource = manager.get_resource(resref)
+                resource = manager.get_resource(resref, resref_type)
                 name = resource.name
             except ResourceError as e:
                 lgr.warning("Manager did not return a resource for %s: %s",

--- a/reproman/interface/tests/test_ls.py
+++ b/reproman/interface/tests/test_ls.py
@@ -13,6 +13,7 @@ import pytest
 
 from ...api import ls
 from ...resource.base import ResourceManager
+from ...support.exceptions import ResourceNotFoundError
 from ...tests.skip import skipif
 
 
@@ -87,3 +88,10 @@ def test_ls_interface_limited(ls_fn):
     assert "326b0fdfbf838" in results
     assert "i-22221ddf096c22bb0" not in results
     assert "i-3333f40de2b9b8967" in results
+
+
+def test_ls_unknown(resource_manager):
+    with patch("reproman.interface.ls.get_manager",
+               return_value=resource_manager):
+        with pytest.raises(ResourceNotFoundError):
+            ls(resrefs=["unknown"], resref_type="name")


### PR DESCRIPTION
This allows a command-line caller to use `reproman ls` to check if a resource exists, as described at gh-521.
