### PR TITLE
DOC: ssh: Mention that SSH config nickname is accepted as host

### DIFF
--- a/reproman/resource/ssh.py
+++ b/reproman/resource/ssh.py
@@ -41,7 +41,8 @@ class SSH(Resource):
     name = attrib(default=attr.NOTHING)
 
     # Configurable options for each "instance"
-    host = attrib(default=attr.NOTHING, doc="DNS or IP address of server")
+    host = attrib(default=attr.NOTHING,
+                  doc="DNS or IP address of server or ssh_config nickname")
     port = attrib(
         doc="Port to connect to on remote host")
     key_filename = attrib(


### PR DESCRIPTION
As explained in e381f4b69 (ENH: ssh: Log connection based on Fabric's
values, 2018-11-27), the Fabric switch means that ssh_config files are
now considered, and the host attribute can point to a nickname, with
things like port configured via ssh_config.

Advertise this to `reproman backend-parameters` callers.