### PR TITLE
Require "-b" for each backend parameter given to "reproman create"

### DIFF
--- a/reproman/interface/create.py
+++ b/reproman/interface/create.py
@@ -65,7 +65,7 @@ class Create(Interface):
         backend_parameters=Parameter(
             metavar="PARAM",
             args=("-b", "--backend-parameters"),
-            nargs="+",
+            action="append", 
             doc="""One or more backend parameters in the form KEY=VALUE. Use
             the command `reproman backend-parameters` to see the list of
             available backend parameters."""


### PR DESCRIPTION
This makes more sense to me, especially with the environment name being a naked command line argument (without a flag) -- which arguably belongs at the end of the command line -- but this isn't possible if -b slurps up everything following it.