### PR TITLE
RF: plain orchestrator - fetch entire job directory

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -890,19 +890,21 @@ class FetchPlainMixin(object):
                 # treat it as the file.
                 op.join(self.local_directory, ""))
 
-        def get_failed_meta(mdir, failed):
-            for idx in failed:
-                for f in ["status", "stdout", "stderr"]:
-                    self.session.get(
-                        op.join(self.meta_directory,
-                                "{}.{:d}".format(f, idx)),
-                        op.join(self.local_directory,
-                                op.relpath(self.meta_directory,
-                                           self.working_directory),
-                                ""))
+        # Fetch all subjobs output
+        local_meta_directory_path = op.join(
+            self.local_directory,
+            op.relpath(self.meta_directory,
+                       self.working_directory),
+            "")
+
+        self.session.get(
+            self.meta_directory,
+            local_meta_directory_path,
+            recursive=True
+        )
 
         failed = self.get_failed_subjobs()
-        self.log_failed(failed, func=get_failed_meta)
+        self.log_failed(failed)
 
         lgr.info("Outputs fetched. Finished with remote resource '%s'",
                  self.resource.name)


### PR DESCRIPTION
It would not work ATM since "get" does not support recursive
copying.
https://github.com/ReproNim/reproman/issues/536
is to address that and be used here after that also for
transfering all the --output(s)