### PR TITLE
Plain orchestrator basic fetch

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -890,19 +890,18 @@ class FetchPlainMixin(object):
                 # treat it as the file.
                 op.join(self.local_directory, ""))
 
-        def get_failed_meta(mdir, failed):
-            for idx in failed:
-                for f in ["status", "stdout", "stderr"]:
-                    self.session.get(
-                        op.join(self.meta_directory,
-                                "{}.{:d}".format(f, idx)),
-                        op.join(self.local_directory,
-                                op.relpath(self.meta_directory,
-                                           self.working_directory),
-                                ""))
+        for idx in range(len(self.job_spec["_command_array"])):
+            for f in ["status", "stdout", "stderr"]:
+                self.session.get(
+                    op.join(self.meta_directory,
+                            "{}.{:d}".format(f, idx)),
+                    op.join(self.local_directory,
+                            op.relpath(self.meta_directory,
+                                       self.working_directory),
+                            ""))
 
         failed = self.get_failed_subjobs()
-        self.log_failed(failed, func=get_failed_meta)
+        self.log_failed(failed)
 
         lgr.info("Outputs fetched. Finished with remote resource '%s'",
                  self.resource.name)

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -104,6 +104,11 @@ def check_orc_plain(tmpdir):
 
             orc.fetch()
             assert open("out").read() == "content\nmore\n"
+
+            metadir_local = op.relpath(orc.meta_directory,
+                                       orc.working_directory)
+            for fname in "status", "stderr", "stdout":
+                assert op.exists(op.join(metadir_local, fname + ".0"))
     return fn
 
 


### PR DESCRIPTION
Modify the plain orchestrator to fetch status, stdout, and stderr back for all jobs.

Closes #535 