### PR TITLE
Travis: Fix 'make -C doc ...' failure in --system-site-packages job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - INSTALL_DATALAD=1
     - INSTALL_CONDOR=1
     - SETUP_SLURM=1
-  - python: 3.5
+  - python: 3.6
     env:
     - REPROMAN_TESTS_SSH=1
     - REPROMAN_TESTS_DEPS=core
@@ -30,7 +30,7 @@ matrix:
       system_site_packages: true
     # We're assuming a system python version.  Pin the dist so that
     # this run doesn't break when the default distribution changes.
-    dist: xenial
+    dist: bionic
   - python: 3.5
     # By default no logs will be output. This one is to test with log output at INFO level
     env:

--- a/reproman/distributions/tests/test_venv.py
+++ b/reproman/distributions/tests/test_venv.py
@@ -64,7 +64,7 @@ def venv_test_dir():
         pip2 = op.join("venv-nonlocal", "bin", "pip")
         runner.run(["virtualenv", "--python", PY_VERSION,
                     "--system-site-packages", "venv-nonlocal"])
-        runner.run([pip2, "install", "attrs"])
+        runner.run([pip2, "install", pymod_dir])
 
     return test_dir
 
@@ -132,8 +132,7 @@ def test_venv_identify_distributions(venv_test_dir):
 def test_venv_system_site_packages(venv_test_dir):
     with chpwd(venv_test_dir):
         tracer = VenvTracer()
-        libpath = op.join("lib", PY_VERSION,
-                          "site-packages", "attr", "filters.py")
+        libpath = op.join("lib", PY_VERSION, "site-packages")
         dists = list(
             tracer.identify_distributions([op.join("venv-nonlocal", libpath)]))
         assert len(dists) == 1
@@ -141,8 +140,8 @@ def test_venv_system_site_packages(venv_test_dir):
         # We won't do detailed inspection of this because its structure depends
         # on a system we don't control, but we still want to make sure that
         # VenvEnvironment's system_site_packages attribute is set correctly.
-        expect = {"environments": [{"packages": [{"files": [libpath],
-                                                  "name": "attrs"}],
+        expect = {"environments": [{"packages": [{"files": [],
+                                                  "name": "nmtest"}],
                                     "system_site_packages": True}]}
         assert_is_subset_recur(expect, attr.asdict(vdist), [dict, list])
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ requires = {
         'pyyaml',
         'tqdm',
         'fabric>=2.3.1',
-        'cryptography>=1.5',
+        'cryptography>=2.5',
         'pytz',
         'scp',
         'pycrypto',


### PR DESCRIPTION
The first two commits prepare the `virtualenv: system_site_packages: true` job for an upgrade from Xenial to Bionic.  The last commit does the upgrade to get the CPython fix described at gh-542.