### PR TITLE
LSF support

### DIFF
--- a/reproman/support/jobs/job_templates/submission/lsf.template
+++ b/reproman/support/jobs/job_templates/submission/lsf.template
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+cat << EOF | bsub -J "reproman[1-{{ _num_subjobs }}]" {{ bsub_opts|default('') }}
+{% if memory is defined %}
+#BSUB -R rusage[mem={{ memory }}]
+{% endif %}
+{% if walltime is defined %}
+#BSUB -W {{ walltime }}
+{% endif %}
+{% if queue is defined %}
+#BSUB -q {{ queue }}
+{% endif %}
+{% if num_process is defined %}
+#BSUB -n {{ num_process }}
+{% endif %}
+#BSUB -o {{ _meta_directory }}/stdout.%I
+#BSUB -e {{ _meta_directory }}/stderr.%I
+
+{{ _meta_directory }}/runscript \$(( \$LSB_JOBINDEX - 1 ))
+EOF
+

--- a/reproman/support/jobs/submitters.py
+++ b/reproman/support/jobs/submitters.py
@@ -359,11 +359,58 @@ class LocalSubmitter(Submitter):
         return status
 
 
+class LSFSubmitter(Submitter):
+    """Submit an LSF job.
+    """
+
+    name = "lsf"
+
+    def __init__(self, session):
+        super(LSFSubmitter, self).__init__(session)
+
+    @property
+    @borrowdoc(Submitter)
+    def submit_command(self):
+        # LSF can ignore the #BSUB directives if the script is given on 
+        # the command line rather than in stdin.  So we use /bin/bash here 
+        # and pipe the script to bsub in the submit script.
+        return ["/bin/bash"]
+
+    @borrowdoc(Submitter)
+    def submit(self, script, submit_command=None):
+        out = super(LSFSubmitter, self).submit(script, submit_command)
+        m = re.search('Job <(\d+)> is submitted to queue', out)
+        self.submission_id = m.group(1)
+        return self.submission_id
+
+    @property
+    @assert_submission_id
+    @borrowdoc(Submitter)
+    def status(self):
+        out, _ = self.session.execute_command(
+            "bjobs -noheader {}".format(self.submission_id))
+        parts = out.split()
+        if not parts:
+            # bjobs might not know about the job if it is still being queued 
+            # and it won't know about the job if some time has passed since 
+            # it terminated
+            return ("unknown", None)
+        assert parts[0] == self.submission_id
+        if parts[2] in ("PEND", "RUN"):
+            return ("waiting", parts[2])
+        if parts[2] in ("DONE", "EXIT"):
+            import traceback
+            traceback.print_stack()
+            return ("completed", parts[2])
+        return ("unknown", parts[2])
+
+
 SUBMITTERS = collections.OrderedDict(
     (o.name, o) for o in [
         PbsSubmitter,
         CondorSubmitter,
         SlurmSubmitter,
         LocalSubmitter,
+        LSFSubmitter, 
     ]
 )

--- a/reproman/support/jobs/submitters.py
+++ b/reproman/support/jobs/submitters.py
@@ -399,8 +399,6 @@ class LSFSubmitter(Submitter):
         if parts[2] in ("PEND", "RUN"):
             return ("waiting", parts[2])
         if parts[2] in ("DONE", "EXIT"):
-            import traceback
-            traceback.print_stack()
             return ("completed", parts[2])
         return ("unknown", parts[2])
 


### PR DESCRIPTION
This PR adds an LSF submitter.

@kyleam, can you recommend the best way to test this?  I'd model off of condor and slurm, but I only see them in test_orchestrators.py (no references to CondorSubmitter or SlurmSubmitter in tests).
