### PR TITLE
BF: DataladOrchestrator: Set DATALAD_SSH_IDENTITYFILE in __init__

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -527,6 +527,14 @@ class DataladOrchestrator(Orchestrator, metaclass=abc.ABCMeta):
             _datalad_check_container(self.ds, self.job_spec)
             _datalad_format_command(self.ds, self.job_spec)
 
+        if isinstance(self.session, SSHSession) and resource.key_filename:
+            # Make the identity file available to 'datalad sshrun' even
+            # if it is not configured in .ssh/config. This is
+            # particularly important for AWS keys.
+            os.environ["DATALAD_SSH_IDENTITYFILE"] = resource.key_filename
+            from datalad import cfg
+            cfg.reload(force=True)
+
     @property
     @cached_property
     @borrowdoc(Orchestrator)
@@ -770,14 +778,6 @@ class PrepareRemoteDataladMixin(object):
         inputs = list(self.get_inputs())
         if isinstance(session, (SSHSession, ShellSession)):
             if isinstance(session, SSHSession):
-                if resource.key_filename:
-                    # Make the identity file available to 'datalad sshrun' even
-                    # if it is not configured in .ssh/config. This is
-                    # particularly important for AWS keys.
-                    os.environ["DATALAD_SSH_IDENTITYFILE"] = resource.key_filename
-                    from datalad import cfg
-                    cfg.reload(force=True)
-
                 target_path = _format_ssh_url(
                     resource.user,
                     # AWS resource does not have host attribute.


### PR DESCRIPTION
DataladOrchestrator.prepare_remote() sets DATALAD_SSH_IDENTITYFILE so
that DataLad can work with SSH targets, in particular those for our
AwsEc2 resource, that need a custom key file that's not specified in
ssh_config.  Doing this in prepare_remote(), however, is problematic
because prepare_remote() isn't necessarily called before other methods
like fetch() that also require DATALAD_SSH_IDENTITYFILE to be
configured.  From the command line, this prevents fetching a job with
`reproman jobs` for a resource that depends on a custom key.

Move the DATALAD_SSH_IDENTITYFILE handling to __init__() so that it is
also in effect for resurrected orchestrators.

Fixes #561.

---

Given the current SSH setup for our tests, I haven't come up with a straightforward way to test this.

@chaselgrove If you have time, could you verify that this fixes the issue you reported?