### PR TITLE
ENH: enable etelemetry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ matrix:
 env:
   global:
     - REPROMAN_TESTS_DEPS=full-except-datalad
+    - NO_ET=1
 
 before_install:
   # we do not need anything from those APT sources, and they often fail, disable!

--- a/reproman/__init__.py
+++ b/reproman/__init__.py
@@ -35,6 +35,16 @@ atexit.register(lgr.log, 5, "Exiting")
 
 from .version import __version__
 
+try:
+    import etelemetry
+
+    etelemetry.check_available_version("repronim/reproman", __version__, lgr=lgr)
+except Exception as exc:
+    lgr.debug(
+        "Failed to check for a more recent version available with etelemetry: %s",
+        exc,
+    )
+
 
 def test(package='reproman', **kwargs):
     """A helper to run reproman's tests.  Requires numpy and pytest

--- a/reproman/tests/test_api.py
+++ b/reproman/tests/test_api.py
@@ -80,9 +80,12 @@ def test_no_heavy_imports():
 
     # new modules brought by import of our .api
     modules = get_modules(', reproman.api').difference(modules0)
-    assert 'requests' not in modules
+    # TODO: add back whenever/if https://github.com/sensein/etelemetry-client/issues/29
+    # is properly addressed
+    #assert 'requests' not in modules
+    # assert len(modules) < 230  # currently 203
     assert 'boto' not in modules
     assert 'jinja2' not in modules
     assert 'paramiko' not in modules
     # and catch it all!  Raise the boundary as needed
-    assert len(modules) < 230  # currently 203
+    assert len(modules) < 550  # currently could be 508 with requests due to etelemetry

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ requires = {
     'core': [
         'appdirs',
         'attrs>=16.3.0',
+        'etelemetry>=0.2.0',
         'humanize',
         'pyyaml',
         'tqdm',


### PR DESCRIPTION
This is a simpler version of https://github.com/ReproNim/reproman/pull/493/files
now that similar code is provided by etelemetry natively.
I decided not to issue warning in case of inability to check, but rather
just log at .debug level