### PR TITLE
Various ENH + RF +BF to make aws_ec2 and ec2_condor (more) usable

### DIFF
--- a/reproman/resource/aws_condor.py
+++ b/reproman/resource/aws_condor.py
@@ -16,6 +16,7 @@ from .base import Resource
 from ..resource import get_manager
 from ..support.jobs.template import Template
 from ..utils import attrib
+# from .aws_ec2 import AwsKeyMixin
 
 
 @attr.s
@@ -41,9 +42,10 @@ class AwsCondor(Resource):
     region_name = attrib(default="us-east-1",
         doc="AWS availability zone to run the EC2 instance in. (e.g. us-east-1)")  # AWS region
     key_name = attrib(
-        doc="AWS subscription name of SSH key-pair registered.")  # Name of SSH key registered on AWS.
+        doc="AWS subscription name of SSH key-pair registered. If not specified, 'name' is used.")  # Name of SSH key
+    # registered on AWS.
     key_filename = attrib(
-        doc="Path to SSH private key file matched with AWS key name parameter.")  # SSH private key filename on local machine.
+        doc="Path to SSH private key file matched with AWS key_name parameter.")  # SSH private key filename on local machine.
     image = attrib(default="ami-0399c674414cb6007",
         doc="AWS image ID from which to create the running instance.")  # NITRC-CE v0.52.0-LITE
     user = attrib(default='ubuntu',
@@ -63,6 +65,17 @@ class AwsCondor(Resource):
         """
         resource_manager = get_manager()
 
+        # TODO Could be done at attrib level?
+        if self.size < 1:
+            raise ValueError("Need at least size=1")
+
+        # TODO: avoid somehow! This duplicates the logic within _ensure_having_a_key
+        # but we cannot use that one here since we would not have a node instance yet
+        # to talk to ec2.  So larger RFing is needed to streamline etc.
+        if not self.key_name:
+            # we must have a key_name since based on it a node might mint a new one
+            self.key_name = self.name
+
         # Create an aws_ec2 instance definition for the master node plus each worker node.
         # Node 0 is the master node.
         if not self.nodes:
@@ -72,11 +85,10 @@ class AwsCondor(Resource):
                 node_configs.append({
                     "type": "aws-ec2",
                     "name": self.name + "_{}".format(i),
-                    "access_key_id": self.access_key_id,
-                    "secret_access_key": self.secret_access_key,
                     "instance_type": self.instance_type,
                     "security_group": self.security_group,
                     "region_name": self.region_name,
+                    # All nodes will reuse this key
                     "key_name": self.key_name,
                     "key_filename": self.key_filename,
                     "image": self.image
@@ -84,6 +96,11 @@ class AwsCondor(Resource):
         else:
             node_configs = self.nodes
             self.nodes = []
+
+        # in either case we need to populate them with secrets
+        for node in node_configs:
+            node['access_key_id'] = self.access_key_id
+            node['secret_access_key'] = self.secret_access_key
 
         # Create a connection for each node in the cluster.
         for i in range(self.size):
@@ -125,9 +142,14 @@ class AwsCondor(Resource):
                 node_inventory.update(resource_attrs)
             return node_inventory
 
+        # Start the first node "manually" to ensure that everything is good
+        # and also possibly to make it produce the ssh key to be used
         with concurrent.futures.ThreadPoolExecutor() as executor:
             for i, node_inventory in enumerate(executor.map(create_ec2, self.nodes)):
                 inventory["nodes"][i].update(node_inventory)
+                if not self.key_filename:
+                    # node (likely 0) must have assigned/produced one
+                    inventory['key_filename'] = self.key_filename = node_inventory['key_filename']
                 yield inventory
 
         lgr.info("Cluster %s is up and running!", self.name)

--- a/reproman/resource/aws_condor.py
+++ b/reproman/resource/aws_condor.py
@@ -207,4 +207,5 @@ class AwsCondor(Resource):
         Log into remote HTCondor cluster (i.e. the manager node)
         """
         # Log into the central manager node
+        lgr.info("FYI IPs of all the nodes: %s", ", ".join(n._ec2_instance.public_ip_address for n in self.nodes))
         return self.nodes[0].get_session(pty, shared)

--- a/reproman/resource/aws_ec2.py
+++ b/reproman/resource/aws_ec2.py
@@ -394,6 +394,11 @@ class AwsEc2(Resource, AwsKeyMixin):
             self.connect()
 
         self._ensure_having_a_key()
+        lgr.info("Establishing session. You can also  ssh -i %s %s@%s",
+                 self.key_filename,
+                 self.user,
+                 self._ec2_instance.public_ip_address,
+                 )
         ssh = SSH(
             self.name,
             host=self._ec2_instance.public_ip_address,

--- a/reproman/resource/tests/test_aws_ec2.py
+++ b/reproman/resource/tests/test_aws_ec2.py
@@ -81,7 +81,7 @@ def test_awsec2_class(resman):
         }
         resource = resman.factory(config)
         resource.connect()
-        assert resource.image == 'ami-c8580bdf'
+        assert resource.image == 'ami-0acbd99fe8c84efbb'
         assert resource.id == 'i-00002777d52482d9c'
         assert resource.instance_type == 't2.micro'
         assert resource.key_filename == '/home/me/.ssh/id_rsa'

--- a/setup.py
+++ b/setup.py
@@ -70,9 +70,7 @@ requires = {
         'chardet',  # python-debian misses dependency on it
     ],
     'datalad': [
-        # Drop the rc as soon as we can to avoid installing future
-        # rcs. See https://github.com/datalad/datalad-container/pull/74.
-        'datalad>=0.13.0rc2',
+        'datalad>=0.13.0',
         'datalad-container',
     ],
     'docker': [


### PR DESCRIPTION
Individual commits have more information.
Changes are quite sloppy but the goal was to make things work:

- the whole dance started with trying to establish a new `ec2_condor` and it asking me for which key_name I want as many times (in parallel) as the `size` ;)  now it would not ask at all!:
- asking for key_name and breeding keys is not nice/good -- now key matches the name by default and we "mint" key_filename to match
  - now if we are to ask for a key_name, we would offer to choose from already present locally keys
- ec2_condor was not really usable without explicit specification of base dir to reside somewhere under `~/nfs-mount`.  Now should function "by default" since `~/.reproman` would be symlinked from that location
- unresolved stumbling point is https://github.com/datalad/datalad/issues/5382 forbidding fetching outputs (and probably upload of inputs if not available "publicly").  For now it requires adding to `~/.ssh/config` entry like
```
Host 54.166.157.42
 IdentityFile /home/yoh/.local/share/reproman/ec2_keys/my-nitrc.pem 
```

Closes #567 

ATM running a "realistic" test case which entailed (work towards fulfilling #548)

- `reproman create yoh-aws-hpc2 -t aws-condor -b size=2 -b key_name=my-nitrc -b instance_type=t2.medium` to establish 2 node cluster
- `reproman run -r yoh-aws-hpc2 --sub condor --orc datalad-pair --jp "container=containers/bids-mriqc" --bp subj=02,13 --follow --input 'sourcedata/sub-{p[subj]}' --output . '{inputs}' . participant group -w workdir --participant_label '{p[subj]}'` to mimic the example of https://github.com/ReproNim/containers#a-typical-workflow .  Tomorrow will see if/where/how it fails