### PR TITLE
BF: orchestrators: Update for change in 'datalad subdatasets' key

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -751,7 +751,14 @@ class PrepareRemoteDataladMixin(object):
             cwd = res["path"]
             self._assert_clean_repo(cwd=cwd)
             lgr.debug("Adjusting state of %s", cwd)
-            cmds = [["git", "checkout", res["revision"]],
+            # "gitshasum" replaced "revision" in v0.12, with the old name kept
+            # for compatibility until v0.14. Even though the minimum version
+            # for DataLad in setup.py is above 0.12, support both keys until
+            # the minimum version for the _remote_ is specified/checked (see
+            # gh-477).
+            revision = res.get("gitshasum", res.get("revision"))
+            assert revision, "bug: incorrectly assumed revision is in results"
+            cmds = [["git", "checkout", revision],
                     ["git", "annex", "init"]]
             for cmd in cmds:
                 try:


### PR DESCRIPTION
In DataLad v0.12.0 (c89746c27e), the "revision" key in the results for
`datalad subdatasets` was changed from "revision" to "gitshasum", and
the old name was kept around for compatibility.  The old key will be
removed in the upcoming 0.14 release (f5c3104d88).

Switch to using "gitshasum".  (Our minimum DataLad version is 0.13, so
a compatibility kludge isn't needed.)

Fixes #568.