### PR TITLE
Adjust tests for Git's init.defaultBranch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,10 @@ jobs:
           sudo eatmydata apt-get install sqlite3 parallel singularity-container
           git config --global user.email "reproman@repronim.org"
           git config --global user.name "ReproMan Tester"
+          # Set defaultBranch to avoid polluting output with repeated
+          # warnings, and set it to something other than "master" to
+          # check that no functionality hard codes the default branch.
+          git config --global init.defaultBranch rman-default-test-branch
       - name: Set up test environment
         run: |
           if [ "${{ matrix.reproman_tests_ssh }}" != "" ]; then

--- a/reproman/distributions/tests/test_vcs.py
+++ b/reproman/distributions/tests/test_vcs.py
@@ -74,6 +74,19 @@ def assert_distributions(result, expected_length=None, which=0,
         assert_is_subset_recur(expected_subset, attr.asdict(dist), [dict, list])
 
 
+def current_hexsha(runner):
+    return runner(["git", "rev-parse", "HEAD"])[0].strip()
+
+
+def current_branch(runner):
+    try:
+        out = runner(["git", "symbolic-ref", "--short", "HEAD"],
+                     expect_fail=True)
+    except CommandError:
+        return
+    return out[0].strip()
+
+
 def test_git_repo_empty(git_repo_empty):
     tracer = VCSTracer()
     # Should not crash when given path to empty repo.
@@ -304,19 +317,6 @@ def install(git_dist, dest, check=False):
 
         for att in ["hexsha", "root_hexsha", "tracked_remote", "remotes"]:
             assert getattr(git_pkg, att) == getattr(git_pkg_installed, att)
-
-
-def current_hexsha(runner):
-    return runner(["git", "rev-parse", "HEAD"])[0].strip()
-
-
-def current_branch(runner):
-    try:
-        out = runner(["git", "symbolic-ref", "--short", "HEAD"],
-                     expect_fail=True)
-    except CommandError:
-        return
-    return out[0].strip()
 
 
 @pytest.mark.integration

--- a/reproman/distributions/tests/test_vcs.py
+++ b/reproman/distributions/tests/test_vcs.py
@@ -403,6 +403,7 @@ def test_git_install_checkout(traced_repo_copy, tmpdir):
     tmpdir = str(tmpdir)
 
     branch = current_branch(GitRunner(traced_repo_copy["repo_local"]))
+    other_branch = "other_" + branch
 
     install_dir = op.join(tmpdir, "installed")
     runner = GitRunner(cwd=install_dir)
@@ -411,20 +412,20 @@ def test_git_install_checkout(traced_repo_copy, tmpdir):
     # Installing to a non-existing location will be more aggressive, creating a
     # new branch at the recorded hexsha rather than just detaching there.
     git_pkg.path = install_dir
-    git_pkg.branch = "other"
+    git_pkg.branch = other_branch
     install(git_dist, install_dir, check=True)
-    assert current_branch(runner) == "other"
+    assert current_branch(runner) == other_branch
 
     # If the recorded branch is in the existing installation repo and has the
     # same hexsha, we check it out.
     run(["git", "checkout", branch])
-    run(["git", "branch", "--force", "other", git_pkg.hexsha])
+    run(["git", "branch", "--force", other_branch, git_pkg.hexsha])
     install(git_dist, install_dir)
     assert current_hexsha(runner) == git_pkg.hexsha
-    assert current_branch(runner) == "other"
+    assert current_branch(runner) == other_branch
     # Otherwise, we detach.
     run(["git", "checkout", branch])
-    run(["git", "branch", "--force", "other", git_pkg.hexsha + "^"])
+    run(["git", "branch", "--force", other_branch, git_pkg.hexsha + "^"])
     install(git_dist, install_dir)
     assert current_hexsha(runner) == git_pkg.hexsha
     assert not current_branch(runner)


### PR DESCRIPTION
This series adjust for Git's 2.28's `init.defaultBranch` configuration option:

 * Update a few test that fail when `init.defaultBranch` is set to a value other than "master".

 * Set `init.defaultBranch` to a value other than "master" in the GitHub CI runs to (1) guard against regressions and (2) silence the many `init.defaultBranch` warnings emitted when running the tests.

~This PR is marked as a draft because it sits on top of gh-571.  Here's the effective diff: https://github.com/repronim/reproman/compare/migrate-to-github-ci...harcoded-master~

