### PR TITLE
MNT: Avoid invalid escape sequences in strings

### DIFF
--- a/reproman/cmdline/helpers.py
+++ b/reproman/cmdline/helpers.py
@@ -65,7 +65,7 @@ class HelpAction(argparse.Action):
             opt_args_str = '*Global options*'
             pos_args_str = '*Commands*'
             # tune up usage -- default one is way too heavy
-            helpstr = re.sub('^[uU]sage: .*?\n\s*\n',
+            helpstr = re.sub(r'^[uU]sage: .*?\n\s*\n',
                              'Usage: reproman [global-opts] command [command-opts]\n\n',
                              helpstr,
                              flags=re.MULTILINE | re.DOTALL)

--- a/reproman/distributions/debian.py
+++ b/reproman/distributions/debian.py
@@ -185,7 +185,7 @@ class DebianDistribution(Distribution):
             import requests  # OPT
             r = requests.get(url)
             m = re.search(
-                '<a href="/archive/\w*debian/(\w+)/dists/\w+/">next change</a>',
+                r'<a href="/archive/\w*debian/(\w+)/dists/\w+/">next change</a>',
                 r.text)
             if m:
                 source_line = template.format(

--- a/reproman/dochelpers.py
+++ b/reproman/dochelpers.py
@@ -105,7 +105,7 @@ def _indent(text, istr=_rst_indentstr):
     return '\n'.join(istr + s for s in text.split('\n'))
 
 
-__parameters_str_re = re.compile("[\n^]\s*:?Parameters?:?\s*\n(:?\s*-+\s*\n)?")
+__parameters_str_re = re.compile(r"[\n^]\s*:?Parameters?:?\s*\n(:?\s*-+\s*\n)?")
 """regexp to match :Parameter: and :Parameters: stand alone in a line
 or
 Parameters
@@ -153,8 +153,8 @@ def _split_out_parameters(initdoc):
            textwrap.dedent(result[2]).strip('\n')
 
 
-__re_params = re.compile('(?:\n\S.*?)+$')
-__re_spliter1 = re.compile('\n(?=\S)')
+__re_params = re.compile(r'(?:\n\S.*?)+$')
+__re_spliter1 = re.compile(r'\n(?=\S)')
 __re_spliter2 = re.compile('[\n:]')
 
 

--- a/reproman/interface/base.py
+++ b/reproman/interface/base.py
@@ -80,28 +80,28 @@ def alter_interface_docs_for_api(docs):
     docs = dedent_docstring(docs)
     # clean cmdline sections
     docs = re.sub(
-        '\|\| CMDLINE \>\>.*\<\< CMDLINE \|\|',
+        r'\|\| CMDLINE \>\>.*\<\< CMDLINE \|\|',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        '\[CMD:\s[^\[\]]*\sCMD\]',
+        r'\[CMD:\s[^\[\]]*\sCMD\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\[PY:\s([^\[\]]*)\sPY\]',
+        r'\[PY:\s([^\[\]]*)\sPY\]',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| PYTHON \>\>(.*)\<\< PYTHON \|\|',
+        r'\|\| PYTHON \>\>(.*)\<\< PYTHON \|\|',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\|\| REFLOW \>\>\n(.*)\<\< REFLOW \|\|',
+        r'\|\| REFLOW \>\>\n(.*)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -117,23 +117,23 @@ def alter_interface_docs_for_cmdline(docs):
     docs = dedent_docstring(docs)
     # clean cmdline sections
     docs = re.sub(
-        '\|\| PYTHON \>\>.*\<\< PYTHON \|\|',
+        r'\|\| PYTHON \>\>.*\<\< PYTHON \|\|',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     # clean cmdline in-line bits
     docs = re.sub(
-        '\[PY:\s[^\[\]]*\sPY\]',
+        r'\[PY:\s[^\[\]]*\sPY\]',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     docs = re.sub(
-        '\[CMD:\s([^\[\]]*)\sCMD\]',
+        r'\[CMD:\s([^\[\]]*)\sCMD\]',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| CMDLINE \>\>(.*)\<\< CMDLINE \|\|',
+        r'\|\| CMDLINE \>\>(.*)\<\< CMDLINE \|\|',
         lambda match: match.group(1),
         docs,
         flags=re.MULTILINE | re.DOTALL)
@@ -147,19 +147,19 @@ def alter_interface_docs_for_cmdline(docs):
     # give option at all, but specifying `None` explicitly is practically
     # impossible
     docs = re.sub(
-        ',\sor\svalue\smust\sbe\s`None`',
+        r',\sor\svalue\smust\sbe\s`None`',
         '',
         docs,
         flags=re.MULTILINE | re.DOTALL)
     # capitalize variables and remove backticks to uniformize with
     # argparse output
     docs = re.sub(
-        '`\S*`',
+        r'`\S*`',
         lambda match: match.group(0).strip('`').upper(),
         docs)
     # clean up sphinx API refs
     docs = re.sub(
-        '\~reproman\.api\.\S*',
+        r'\~reproman\.api\.\S*',
         lambda match: "`{0}`".format(match.group(0)[13:]),
         docs)
     # Remove RST paragraph markup
@@ -169,7 +169,7 @@ def alter_interface_docs_for_cmdline(docs):
         docs,
         flags=re.MULTILINE)
     docs = re.sub(
-        '\|\| REFLOW \>\>\n(.*)\<\< REFLOW \|\|',
+        r'\|\| REFLOW \>\>\n(.*)\<\< REFLOW \|\|',
         lambda match: textwrap.fill(match.group(1)),
         docs,
         flags=re.MULTILINE | re.DOTALL)

--- a/reproman/resource/tests/test_shell.py
+++ b/reproman/resource/tests/test_shell.py
@@ -135,7 +135,7 @@ def test_shell_resource(resman):
     resource = resman.factory(config)
 
     status = merge_dicts(resource.create())
-    assert re.match('\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$', status['id']) is not None
+    assert re.match(r'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$', status['id']) is not None
 
     assert type(resource.connect()) == Shell
     assert resource.delete() is None

--- a/reproman/resource/tests/test_ssh.py
+++ b/reproman/resource/tests/test_ssh.py
@@ -60,7 +60,7 @@ def test_ssh_class(setup_ssh, resource_test_dir, resman):
         resource = resman.factory(config)
         updated_config = merge_dicts(resource.create())
         config.update(updated_config)
-        assert re.match('\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$',
+        assert re.match(r'\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$',
                         resource.id) is not None
         assert resource.status == 'N/A'
 

--- a/reproman/support/constraints.py
+++ b/reproman/support/constraints.py
@@ -15,7 +15,7 @@ import re
 def _strip_typerepr(s):
     """Strip away <class '...'> and <type '...'> decorations for docstrings
     """
-    return re.sub("<(class|type) '(\S+)'>", r'\2', s)
+    return re.sub(r"<(class|type) '(\S+)'>", r'\2', s)
 
 
 def _type_str(t):

--- a/reproman/support/distributions/debian.py
+++ b/reproman/support/distributions/debian.py
@@ -53,7 +53,7 @@ def get_spec_from_release_file(content):
     """Provide specification object describing the component of the distribution
     """
     # RegExp to pull a single line "tag: value" pair from a deb822 file
-    re_deb822_single_line_tag = re.compile("""
+    re_deb822_single_line_tag = re.compile(r"""
         ^(?P<tag>[a-zA-Z][^:]*):[\ ]+  # Tag - begins at start of line
         (?P<val>\S.*)$           # Value - after colon to the end of the line
     """, flags=re.VERBOSE + re.MULTILINE)
@@ -82,12 +82,12 @@ def parse_apt_cache_show_pkgs_output(output):
                                     flags=re.MULTILINE))
 
     # RegExp to pull a single line "tag: value" pair from a deb822 file
-    re_deb822_single_line_tag = re.compile("""
+    re_deb822_single_line_tag = re.compile(r"""
         ^(?P<tag>[a-zA-Z][^:]*):[\ ]+  # Tag - begins at start of line
         (?P<val>\S.*)$           # Value - after colon to the end of the line
     """, flags=re.VERBOSE + re.MULTILINE)
     # RegExp to split source into source and version
-    re_source = re.compile("""
+    re_source = re.compile(r"""
         ^(?P<source_name>[^ ]+)                # source name before any space
         ([^(]*\((?P<source_version>[^)]+)\))?  # source version in parentheses
     """, flags=re.VERBOSE)
@@ -116,9 +116,9 @@ def parse_apt_cache_show_pkgs_output(output):
 def parse_apt_cache_policy_pkgs_output(output):
     # findall wasn't greedy enough for some reason, so decided first to
     # split into entries (one per package)
-    entries = filter(bool, re.split('\n(?=\S)', output, flags=re.MULTILINE))
+    entries = filter(bool, re.split(r'\n(?=\S)', output, flags=re.MULTILINE))
     # now we need to parse/match each entry
-    re_pkg = re.compile("""
+    re_pkg = re.compile(r"""
         ^(?P<name>[^\s:]+):((?P<architecture>\S+):)?\s*\n  # package name
         \s+Installed:\s*(?P<installed>\S*)\s*\n    # Installed version
         \s+Candidate:\s*(?P<candidate>\S*)\s*\n    # Candidate version
@@ -126,13 +126,13 @@ def parse_apt_cache_policy_pkgs_output(output):
         (?P<version_table>(\n\s.*)+)
         """, flags=re.VERBOSE)
 
-    re_versions = re.compile("""
+    re_versions = re.compile(r"""
         ^(\s{5}|\s(?P<installed>\*\*\*)\s)
         (?P<version>\S+)\s+
         (?P<priority>\S+)
         (?P<sources>(\n\s{8}.*)+)
     """, flags=re.VERBOSE + re.MULTILINE)
-    re_source = re.compile("""
+    re_source = re.compile(r"""
         ^\s{8}(?P<priority>\S+)\s+
         (?P<source>.*)$
     """, flags=re.VERBOSE + re.MULTILINE)
@@ -160,13 +160,13 @@ def parse_apt_cache_policy_pkgs_output(output):
 
 def parse_apt_cache_policy_source_info(policy_output):
     source_info = {}
-    re_section = re.compile("""
+    re_section = re.compile(r"""
         ^(?P<header_line>\S.*)$[\r\n]*  # Header - non whitespace at the
                                         #          beginning of the line
         (?P<body>(^\ .*$[\r\n]*)*)      # Body - All subsequent lines that
                                         #        begin with a space
         """, flags=re.VERBOSE + re.MULTILINE)
-    re_source = re.compile("""
+    re_source = re.compile(r"""
         ^(\ (?P<priority>[0-9]+)\ +(?P<source>.*)$[\r\n]+
          (^(
             (\ \ +release\ +(?P<release_info>.*))|
@@ -182,7 +182,7 @@ def parse_apt_cache_policy_source_info(policy_output):
                            # The value follows the "=", and include any
                            # non commas, or commas not followed by another tag
         """, flags=re.VERBOSE)
-    re_source_line = re.compile("""
+    re_source_line = re.compile(r"""
         (?P<archive_uri>\S+)        # Archive URI up to the first " "
         (\ (?P<uri_suite>[^/]+))?   # The suite goes up to the first "/"
         """, flags=re.VERBOSE)

--- a/reproman/support/distributions/debian.py
+++ b/reproman/support/distributions/debian.py
@@ -129,7 +129,7 @@ def parse_apt_cache_policy_pkgs_output(output):
     re_versions = re.compile("""
         ^(\s{5}|\s(?P<installed>\*\*\*)\s)
         (?P<version>\S+)\s+
-        (?P<priority>\S+)\n.*
+        (?P<priority>\S+)
         (?P<sources>(\n\s{8}.*)+)
     """, flags=re.VERBOSE + re.MULTILINE)
     re_source = re.compile("""

--- a/reproman/support/jobs/submitters.py
+++ b/reproman/support/jobs/submitters.py
@@ -379,7 +379,7 @@ class LSFSubmitter(Submitter):
     @borrowdoc(Submitter)
     def submit(self, script, submit_command=None):
         out = super(LSFSubmitter, self).submit(script, submit_command)
-        m = re.search('Job <(\d+)> is submitted to queue', out)
+        m = re.search(r'Job <(\d+)> is submitted to queue', out)
         self.submission_id = m.group(1)
         # Although LSF may have submitted the job successfully, it might 
         # not show up in the queue immediately.  We wait here for it to 

--- a/reproman/support/param.py
+++ b/reproman/support/param.py
@@ -16,7 +16,7 @@ from reproman.utils import getargspec
 
 from .constraints import expand_constraint_spec
 
-_whitespace_re = re.compile('\n\s+|^\s+')
+_whitespace_re = re.compile(r'\n\s+|^\s+')
 
 
 class Parameter(object):

--- a/reproman/tests/test_cmdline_main.py
+++ b/reproman/tests/test_cmdline_main.py
@@ -73,7 +73,7 @@ def test_help_np():
     # enough of bin/reproman and .tox/py27/bin/reproman -- guarantee consistency! ;)
     ok_startswith(stdout, 'Usage: reproman')
     # Sections start/end with * if ran under REPROMAN_HELP2MAN mode
-    sections = [l[1:-1] for l in filter(re.compile('^\*.*\*$').match, stdout.split('\n'))]
+    sections = [l[1:-1] for l in filter(re.compile(r'^\*.*\*$').match, stdout.split('\n'))]
     # but order is still not guaranteed (dict somewhere)! TODO
     # see https://travis-ci.org/reproman/reproman/jobs/80519004
     # thus testing sets

--- a/reproman/tests/test_dochelpers.py
+++ b/reproman/tests/test_dochelpers.py
@@ -141,7 +141,7 @@ def test_exc_str():
         raise Exception("my bad")
     except Exception as e:
         estr = exc_str(e)
-    assert_re_in("my bad \[test_dochelpers.py:test_exc_str:...\]", estr)
+    assert_re_in(r"my bad \[test_dochelpers.py:test_exc_str:...\]", estr)
 
     def f():
         def f2():
@@ -159,12 +159,12 @@ def test_exc_str():
         with patch.dict('os.environ', {}, clear=True):
             estr_ = exc_str()
 
-    assert_re_in("my bad again \[test_dochelpers.py:test_exc_str:...,test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr3)
-    assert_re_in("my bad again \[test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr2)
-    assert_re_in("my bad again \[test_dochelpers.py:f2:...\]", estr1)
+    assert_re_in(r"my bad again \[test_dochelpers.py:test_exc_str:...,test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr3)
+    assert_re_in(r"my bad again \[test_dochelpers.py:f:...,test_dochelpers.py:f2:...\]", estr2)
+    assert_re_in(r"my bad again \[test_dochelpers.py:f2:...\]", estr1)
     assert_equal(estr_, estr1)
 
     try:
         raise NotImplementedError
     except Exception as e:
-        assert_re_in("NotImplementedError\(\) \[test_dochelpers.py:test_exc_str:...\]", exc_str(e))
+        assert_re_in(r"NotImplementedError\(\) \[test_dochelpers.py:test_exc_str:...\]", exc_str(e))

--- a/reproman/tests/test_log.py
+++ b/reproman/tests/test_log.py
@@ -39,7 +39,7 @@ def test_logging_to_a_file(dst=None):
     # verify that time stamp and level are present in the log line
     # do not want to rely on not having race conditions around date/time changes
     # so matching just with regexp
-    ok_(re.match("\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \[ERROR\] %s" % msg,
+    ok_(re.match(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} \[ERROR\] %s" % msg,
                  line))
 
 @with_tempfile

--- a/reproman/tests/test_utils.py
+++ b/reproman/tests/test_utils.py
@@ -307,7 +307,7 @@ def test_find_files():
     assert_in(tests_dir, files2)
 
     # now actually matching the path
-    ff3 = find_files('.*/test_.*\.py$', proj_dir, dirs=True)
+    ff3 = find_files(r'.*/test_.*\.py$', proj_dir, dirs=True)
     files3 = list(ff3)
     assert_in(opj(tests_dir, 'test_utils.py'), files3)
     assert_not_in(tests_dir, files3)

--- a/reproman/utils.py
+++ b/reproman/utils.py
@@ -184,8 +184,8 @@ def sorted_files(dout):
                        if not '.git' in r], []))
 
 from os.path import sep as dirsep
-_VCS_REGEX = '%s\.(?:git|gitattributes|svn|bzr|hg)(?:%s|$)' % (dirsep, dirsep)
-_REPROMAN_REGEX = '%s\.(?:reproman)(?:%s|$)' % (dirsep, dirsep)
+_VCS_REGEX = r'%s\.(?:git|gitattributes|svn|bzr|hg)(?:%s|$)' % (dirsep, dirsep)
+_REPROMAN_REGEX = r'%s\.(?:reproman)(?:%s|$)' % (dirsep, dirsep)
 
 
 def find_files(regex, topdir=curdir, exclude=None, exclude_vcs=True, exclude_reproman=False, dirs=False):
@@ -333,7 +333,7 @@ def file_basename(name, return_ext=False):
     not a digit, so we could get rid of .tar.gz etc
     """
     bname = basename(name)
-    fbname = re.sub('(\.[a-zA-Z_]\S{1,4}){0,2}$', '', bname)
+    fbname = re.sub(r'(\.[a-zA-Z_]\S{1,4}){0,2}$', '', bname)
     if return_ext:
         return fbname, bname[len(fbname)+1:]
     else:

--- a/reproman/version.py
+++ b/reproman/version.py
@@ -23,7 +23,8 @@ if lexists(opj(projdir, '.git')):
         import sys
         from subprocess import Popen, PIPE
         from os.path import dirname
-        git = Popen(['git', 'describe', '--abbrev=4', '--dirty', '--match', '[0-9]*\.*'],
+        git = Popen(['git', 'describe', '--abbrev=4', '--dirty', '--match',
+                     r'[0-9]*\.*'],
                     stdout=PIPE, stderr=PIPE,
                     cwd=projdir)
         if git.wait() != 0:


### PR DESCRIPTION
A good number of regexps and a few other strings don't use an r-prefix
when the string contains non-escape-sequence backslashes.  This
doesn't make a functional difference at the moment because, when
Python encounters a backslash that produces an invalid escape
sequence, it automatically escapes the backslash.  But Python 3.6 and
later give a DeprecationWarning (<https://bugs.python.org/issue32912>),
with the goal of eventually making invalid escape sequences a syntax
error.

---

~This PR is marked as a draft because it sits on top of gh-571.  Here's the effective diff: https://github.com/repronim/reproman/compare/migrate-to-github-ci...invalid-escapes~
