### PR TITLE
BF: orchestrators: Call datalad-push with --data=nothing

### DIFF
--- a/reproman/support/jobs/orchestrators.py
+++ b/reproman/support/jobs/orchestrators.py
@@ -836,7 +836,7 @@ class PrepareRemoteDataladMixin(object):
             if need_push:
                 call_check_dl_results(
                     self.ds.push, "'datalad push' failed",
-                    to=resource.name, since=since, data="auto",
+                    to=resource.name, since=since, data="nothing",
                     recursive=True, on_failure="ignore")
 
             self._fix_up_dataset()


### PR DESCRIPTION
When 5f982f216 (2021-03-03) switched datalad-publish to datalad-push,
data="auto" was used to retain the behavior of the publish() call.
However, as mentioned in that commit and gh-575 [*], data="nothing" is
preferable here.  The original publish() call didn't use
transfer_data="auto" because there was an intent to transfer data
according to any configured preferred content; I just thoughtlessly
left the option at the default value.

[*] https://github.com/ReproNim/reproman/pull/575#issuecomment-790090050