### PR TITLE
BF: job_templates: Store launcher subjob output in expected files

### DIFF
--- a/reproman/support/jobs/job_templates/submission/launcher.template
+++ b/reproman/support/jobs/job_templates/submission/launcher.template
@@ -4,7 +4,8 @@ module load launcher
 export LAUNCHER_JOB_FILE="$metadir/launcher"
 
 for task_id in $(seq 0 {{ _num_subjobs - 1}}); do
-    echo "$metadir/runscript $task_id" >> "$LAUNCHER_JOB_FILE"
+    printf "$metadir/runscript %d >$metadir/stdout.%d 2>$metadir/stderr.%d\n" \
+      "$task_id" "$task_id" "$task_id" >>"$LAUNCHER_JOB_FILE"
 done
 
 "$LAUNCHER_DIR"/paramrun

--- a/reproman/support/jobs/job_templates/submission/launcher.template
+++ b/reproman/support/jobs/job_templates/submission/launcher.template
@@ -1,8 +1,10 @@
+metadir={{ shlex_quote(_meta_directory) }}
+
 module load launcher
-export LAUNCHER_JOB_FILE="{{ shlex_quote(_meta_directory) }}/launcher"
+export LAUNCHER_JOB_FILE="$metadir/launcher"
 
 for task_id in $(seq 0 {{ _num_subjobs - 1}}); do
-    echo "{{ shlex_quote(_meta_directory) }}/runscript $task_id" >> "$LAUNCHER_JOB_FILE"
+    echo "$metadir/runscript $task_id" >> "$LAUNCHER_JOB_FILE"
 done
 
 "$LAUNCHER_DIR"/paramrun

--- a/reproman/support/jobs/job_templates/submission/slurm.template
+++ b/reproman/support/jobs/job_templates/submission/slurm.template
@@ -1,7 +1,13 @@
 #!/bin/sh
 
+{% if launcher is defined and launcher == "true" %}
+#SBATCH --output={{ shlex_quote(_meta_directory) }}/stdout
+#SBATCH --error={{ shlex_quote(_meta_directory) }}/stderr
+{% else %}
 #SBATCH --output={{ shlex_quote(_meta_directory) }}/stdout.%a
 #SBATCH --error={{ shlex_quote(_meta_directory) }}/stderr.%a
+{% endif %}
+
 {#
   TODO: We need to assess how we treat batch parameters across different
   submitters---things like whether we should try to expose common names and, if

--- a/reproman/support/jobs/tests/test_orchestrators.py
+++ b/reproman/support/jobs/tests/test_orchestrators.py
@@ -740,6 +740,11 @@ def check_orc_datalad_concurrent(job_spec, dataset):
                 assert dataset.repo.file_has_content(ofile)
                 with open(ofile) as ofh:
                     assert ofh.read() == ofile[0] * 2
+
+            metadir = op.relpath(orc.meta_directory, orc.working_directory)
+            for idx in range(len(orc.job_spec["_command_array"])):
+                for fname in "status", "stderr", "stdout":
+                    assert op.lexists(op.join(metadir, f"{fname}.{idx}"))
     return fn
 
 


### PR DESCRIPTION
Submit templates direct subjob output to
`$metadir/{stdout,stderr}.{0,..,$subjobs - 1}`.  The recently added
launcher handling, however, breaks this setup, creating just two files
with all the output (one for stdout and one for stderr).  In the case
of Slurm, the output files are `$metadir/{stdout,stderr}.4294967294`
because the files are constructed with "%a", which gets set to the
above value when there is no job array [1].

Rework launcher.template so that stdout and stderr are written to the
expected files.

[1] https://slurm.schedmd.com/job_array.html

Re: #578

---

Thanks to @jdkent for reporting.
